### PR TITLE
feat: Session 3b — baton-list metadata flags (--avu/--acl/--replicate/--timestamp)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,13 @@ fn main() {
         // to read size / checksum without a full catalog query.
         .allowlist_function("rcObjStat")
         .allowlist_function("freeRodsObjStat")
+        // General catalog query — every metadata flag (--avu / --acl /
+        // --replicate / --timestamp) goes through rcGenQuery.
+        .allowlist_function("rcGenQuery")
+        .allowlist_function("addInxIval")
+        .allowlist_function("addInxVal")
+        .allowlist_function("clearGenQueryInp")
+        .allowlist_function("freeGenQueryOut")
         // Types referenced by those functions.
         .allowlist_type("rcComm_t")
         .allowlist_type("rodsEnv")
@@ -50,12 +57,19 @@ fn main() {
         .allowlist_type("dataObjInp_t")
         .allowlist_type("rodsObjStat_t")
         .allowlist_type("objType_t")
+        .allowlist_type("genQueryInp_t")
+        .allowlist_type("genQueryOut_t")
+        .allowlist_type("sqlResult_t")
+        .allowlist_type("inxIvalPair_t")
+        .allowlist_type("inxValPair_t")
         // Error code constants used when translating iRODS codes into
         // BatonError. The allowlist is broad on purpose — constants are cheap.
         .allowlist_var("CAT_.*")
         .allowlist_var("SYS_.*")
         .allowlist_var("AUTH_.*")
         .allowlist_var("USER_.*")
+        // Catalog column numeric indices used in SELECT / WHERE.
+        .allowlist_var("COL_.*")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("bindgen: failed to generate iRODS bindings");

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -187,7 +187,13 @@ impl RodsConnection {
 
             // A successful query that matched no rows returns
             // CAT_NO_ROWS_FOUND (-808000). Report as empty, not an error.
-            if status as i32 == ffi::CAT_NO_ROWS_FOUND as i32 {
+            //
+            // bindgen doesn't surface the constant from rodsClient.h's
+            // transitive includes — the symbol must live behind a header
+            // that wrapper.h doesn't reach. Hardcode the well-known value
+            // rather than expanding wrapper.h for one constant.
+            const CAT_NO_ROWS_FOUND: i32 = -808000;
+            if status == CAT_NO_ROWS_FOUND {
                 return Ok(rows);
             }
             if status < 0 {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -161,6 +161,75 @@ impl RodsConnection {
         Ok(result)
     }
 
+    /// Execute a prepared `genQueryInp_t` and return every matching row as
+    /// a flat `Vec<Vec<String>>`. Pagination via `continueInx` is handled
+    /// internally — callers see one combined result.
+    ///
+    /// The caller is responsible for populating the SELECT / WHERE pairs
+    /// (via `addInxIval` / `addInxVal`) and for calling
+    /// `clearGenQueryInp` on the input after this method returns.
+    /// `CAT_NO_ROWS_FOUND` is treated as a normal empty result, not an
+    /// error — any other negative status becomes a `BatonError`.
+    ///
+    /// `pub(crate)` because the `genQueryInp_t` type is crate-internal; we
+    /// don't want to leak raw iRODS structs through the public API. The
+    /// per-flag helpers in `crate::operations` build the input locally and
+    /// expose typed wrappers.
+    pub(crate) fn query(
+        &mut self,
+        inp: &mut ffi::genQueryInp_t,
+    ) -> Result<Vec<Vec<String>>, BatonError> {
+        let mut rows: Vec<Vec<String>> = Vec::new();
+
+        loop {
+            let mut out: *mut ffi::genQueryOut_t = std::ptr::null_mut();
+            let status = unsafe { ffi::rcGenQuery(self.conn, inp, &mut out) };
+
+            // A successful query that matched no rows returns
+            // CAT_NO_ROWS_FOUND (-808000). Report as empty, not an error.
+            if status as i32 == ffi::CAT_NO_ROWS_FOUND as i32 {
+                return Ok(rows);
+            }
+            if status < 0 {
+                return Err(BatonError::from_irods(status));
+            }
+            if out.is_null() {
+                return Err(BatonError {
+                    code: -1,
+                    message: "rcGenQuery returned null with non-negative status".to_string(),
+                });
+            }
+
+            // Read out all rows in this page. sqlResult[c].value is a flat
+            // buffer — row `r`'s value for column `c` lives at offset
+            // `r * sqlResult[c].len`, NUL-terminated within that slot.
+            let out_ref = unsafe { &*out };
+            for row_idx in 0..out_ref.rowCnt {
+                let mut row = Vec::with_capacity(out_ref.attriCnt as usize);
+                for col_idx in 0..out_ref.attriCnt {
+                    let sql = &out_ref.sqlResult[col_idx as usize];
+                    let offset = (row_idx * sql.len) as isize;
+                    let value_ptr = unsafe { sql.value.offset(offset) };
+                    let s = unsafe { CStr::from_ptr(value_ptr as *const _) }
+                        .to_string_lossy()
+                        .into_owned();
+                    row.push(s);
+                }
+                rows.push(row);
+            }
+
+            let continue_inx = out_ref.continueInx;
+            unsafe { ffi::freeGenQueryOut(&mut out) };
+
+            if continue_inx <= 0 {
+                break;
+            }
+            inp.continueInx = continue_inx;
+        }
+
+        Ok(rows)
+    }
+
     /// Tear down the current connection and build a fresh one in its
     /// place, re-authenticating via [`Self::login_from_auth_file`].
     ///

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -231,19 +231,31 @@ fn fetch_avus(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Avu>, Ba
         .collect())
 }
 
-/// Fetch the ACL entries attached to a target. iRODS auto-joins the user
-/// table when both `COL_USER_*` and an access-name column appear in the
-/// same query, so we can read user, zone, and access level in one row.
+/// Fetch the ACL entries attached to a target.
+///
+/// Collection ACLs need the *collection-specific* user-name and zone
+/// columns (`COL_COLL_USER_NAME` / `COL_COLL_USER_ZONE`) — the generic
+/// `COL_USER_NAME` / `COL_USER_ZONE` columns join via the data-access
+/// path, so on a collection input they yield zero rows. baton's own
+/// source uses the same split.
 fn fetch_acl(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Acl>, BatonError> {
     let mut inp = new_query_inp();
     let inp_ref = unsafe { inp.assume_init_mut() };
 
-    let col_access_name = match target {
-        Target::DataObject(_) => ffi::COL_DATA_ACCESS_NAME as i32,
-        Target::Collection(_) => ffi::COL_COLL_ACCESS_NAME as i32,
+    let (col_user_name, col_user_zone, col_access_name) = match target {
+        Target::DataObject(_) => (
+            ffi::COL_USER_NAME as i32,
+            ffi::COL_USER_ZONE as i32,
+            ffi::COL_DATA_ACCESS_NAME as i32,
+        ),
+        Target::Collection(_) => (
+            ffi::COL_COLL_USER_NAME as i32,
+            ffi::COL_COLL_USER_ZONE as i32,
+            ffi::COL_COLL_ACCESS_NAME as i32,
+        ),
     };
-    add_select(inp_ref, ffi::COL_USER_NAME as i32);
-    add_select(inp_ref, ffi::COL_USER_ZONE as i32);
+    add_select(inp_ref, col_user_name);
+    add_select(inp_ref, col_user_zone);
     add_select(inp_ref, col_access_name);
 
     match target {

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -116,12 +116,16 @@ fn add_where(
 /// Run a populated input and always clear it before returning, regardless
 /// of whether the query succeeded — `clearGenQueryInp` frees the
 /// strdup'd condition / select buffers.
+///
+/// iRODS declares `clearGenQueryInp` with a generic `void *` parameter
+/// (it shares the signature with other `clearXxx` helpers). bindgen
+/// reflects that faithfully; we cast through `*mut _` here.
 fn run_query(
     conn: &mut RodsConnection,
     inp: &mut ffi::genQueryInp_t,
 ) -> Result<Vec<Vec<String>>, BatonError> {
     let result = conn.query(inp);
-    unsafe { ffi::clearGenQueryInp(inp) };
+    unsafe { ffi::clearGenQueryInp(inp as *mut _ as *mut std::os::raw::c_void) };
     result
 }
 

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -14,7 +14,7 @@ use std::mem::MaybeUninit;
 use crate::connection::RodsConnection;
 use crate::error::BatonError;
 use crate::ffi;
-use crate::types::{Avu, Target};
+use crate::types::{Acl, AclLevel, Avu, Target};
 
 /// Which optional fields the caller wants populated in the output.
 #[derive(Debug, Default, Clone, Copy)]
@@ -62,6 +62,14 @@ pub fn list_one(
         match &mut target {
             Target::DataObject(d) => d.avus = Some(avus),
             Target::Collection(c) => c.avus = Some(avus),
+        }
+    }
+
+    if opts.acl {
+        let acls = fetch_acl(conn, &target)?;
+        match &mut target {
+            Target::DataObject(d) => d.access = Some(acls),
+            Target::Collection(c) => c.access = Some(acls),
         }
     }
 
@@ -205,6 +213,113 @@ fn fetch_avus(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Avu>, Ba
             }
         })
         .collect())
+}
+
+/// Fetch the ACL entries attached to a target. iRODS auto-joins the user
+/// table when both `COL_USER_*` and an access-name column appear in the
+/// same query, so we can read user, zone, and access level in one row.
+fn fetch_acl(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Acl>, BatonError> {
+    let mut inp = new_query_inp();
+    let inp_ref = unsafe { inp.assume_init_mut() };
+
+    let col_access_name = match target {
+        Target::DataObject(_) => ffi::COL_DATA_ACCESS_NAME as i32,
+        Target::Collection(_) => ffi::COL_COLL_ACCESS_NAME as i32,
+    };
+    add_select(inp_ref, ffi::COL_USER_NAME as i32);
+    add_select(inp_ref, ffi::COL_USER_ZONE as i32);
+    add_select(inp_ref, col_access_name);
+
+    match target {
+        Target::DataObject(d) => {
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.collection)),
+            )?;
+            add_where(
+                inp_ref,
+                ffi::COL_DATA_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.data_object)),
+            )?;
+        }
+        Target::Collection(c) => {
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&c.collection)),
+            )?;
+        }
+    }
+
+    let rows = run_query(conn, inp_ref)?;
+
+    rows.into_iter()
+        .map(|row| {
+            let owner = row.first().cloned().unwrap_or_default();
+            let zone_raw = row.get(1).cloned().unwrap_or_default();
+            let level_str = row.get(2).cloned().unwrap_or_default();
+            let level = parse_acl_level(&level_str)?;
+            // baton's schema treats `zone` as optional; fold an empty
+            // server-side zone string to None so the JSON omits it.
+            let zone = if zone_raw.is_empty() {
+                None
+            } else {
+                Some(zone_raw)
+            };
+            Ok(Acl { owner, level, zone })
+        })
+        .collect()
+}
+
+/// Map iRODS's catalog access-level string into our typed enum. iRODS
+/// uses the verbose forms `read object` / `modify object`; baton (and
+/// our JSON schema) prefer the compact `read` / `write`. Both forms are
+/// accepted here so behaviour is stable across iRODS server versions
+/// that have shipped slightly different strings.
+fn parse_acl_level(s: &str) -> Result<AclLevel, BatonError> {
+    match s {
+        "null" => Ok(AclLevel::Null),
+        "read" | "read object" => Ok(AclLevel::Read),
+        "write" | "modify object" => Ok(AclLevel::Write),
+        "own" => Ok(AclLevel::Own),
+        other => Err(BatonError {
+            code: -1,
+            message: format!("unknown iRODS access level: {:?}", other),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_acl_level_accepts_compact_and_verbose_forms() {
+        assert_eq!(parse_acl_level("null").unwrap(), AclLevel::Null);
+        assert_eq!(parse_acl_level("read").unwrap(), AclLevel::Read);
+        assert_eq!(parse_acl_level("read object").unwrap(), AclLevel::Read);
+        assert_eq!(parse_acl_level("write").unwrap(), AclLevel::Write);
+        assert_eq!(parse_acl_level("modify object").unwrap(), AclLevel::Write);
+        assert_eq!(parse_acl_level("own").unwrap(), AclLevel::Own);
+    }
+
+    #[test]
+    fn parse_acl_level_errors_on_unknown_string() {
+        let err = parse_acl_level("inherit").unwrap_err();
+        assert!(
+            err.message.contains("unknown iRODS access level"),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn sql_escape_doubles_single_quotes() {
+        assert_eq!(sql_escape("plain"), "plain");
+        assert_eq!(sql_escape("O'Brien"), "O''Brien");
+        assert_eq!(sql_escape("''"), "''''");
+    }
 }
 
 /// Same as [`list_one`], but catches iRODS errors and emits the input

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -14,7 +14,7 @@ use std::mem::MaybeUninit;
 use crate::connection::RodsConnection;
 use crate::error::BatonError;
 use crate::ffi;
-use crate::types::{Acl, AclLevel, Avu, Target};
+use crate::types::{Acl, AclLevel, Avu, DataObject, Replicate, Target};
 
 /// Which optional fields the caller wants populated in the output.
 #[derive(Debug, Default, Clone, Copy)]
@@ -70,6 +70,14 @@ pub fn list_one(
         match &mut target {
             Target::DataObject(d) => d.access = Some(acls),
             Target::Collection(c) => c.access = Some(acls),
+        }
+    }
+
+    // Replicates are a data-object concept; baton silently ignores
+    // --replicate on collections, and we follow suit.
+    if opts.replicate {
+        if let Target::DataObject(d) = &mut target {
+            d.replicates = Some(fetch_replicates(conn, d)?);
         }
     }
 
@@ -277,6 +285,63 @@ fn fetch_acl(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Acl>, Bat
 /// our JSON schema) prefer the compact `read` / `write`. Both forms are
 /// accepted here so behaviour is stable across iRODS server versions
 /// that have shipped slightly different strings.
+/// Fetch the replicas of a data object. Each row from the catalog becomes
+/// one [`Replicate`].
+///
+/// `valid` is derived from `COL_D_REPL_STATUS`: iRODS uses `1` for a good
+/// replica and `0` (or `4` mid-write, etc.) for not-good. We collapse
+/// anything other than literal `"1"` to `false` — matches baton's
+/// behaviour and keeps callers from having to know iRODS's status codes.
+fn fetch_replicates(
+    conn: &mut RodsConnection,
+    d: &DataObject,
+) -> Result<Vec<Replicate>, BatonError> {
+    let mut inp = new_query_inp();
+    let inp_ref = unsafe { inp.assume_init_mut() };
+
+    add_select(inp_ref, ffi::COL_D_REPL_NUM as i32);
+    add_select(inp_ref, ffi::COL_D_DATA_CHECKSUM as i32);
+    add_select(inp_ref, ffi::COL_R_LOC as i32);
+    add_select(inp_ref, ffi::COL_D_RESC_NAME as i32);
+    add_select(inp_ref, ffi::COL_D_REPL_STATUS as i32);
+
+    add_where(
+        inp_ref,
+        ffi::COL_COLL_NAME as i32,
+        &format!("= '{}'", sql_escape(&d.collection)),
+    )?;
+    add_where(
+        inp_ref,
+        ffi::COL_DATA_NAME as i32,
+        &format!("= '{}'", sql_escape(&d.data_object)),
+    )?;
+
+    let rows = run_query(conn, inp_ref)?;
+
+    rows.into_iter()
+        .map(|row| {
+            let number_str = row.first().cloned().unwrap_or_default();
+            let checksum = row.get(1).cloned().unwrap_or_default();
+            let location = row.get(2).cloned().unwrap_or_default();
+            let resource = row.get(3).cloned().unwrap_or_default();
+            let status = row.get(4).cloned().unwrap_or_default();
+
+            let number: u32 = number_str.parse().map_err(|_| BatonError {
+                code: -1,
+                message: format!("non-numeric replica number: {:?}", number_str),
+            })?;
+
+            Ok(Replicate {
+                checksum,
+                location,
+                resource,
+                number,
+                valid: status == "1",
+            })
+        })
+        .collect()
+}
+
 fn parse_acl_level(s: &str) -> Result<AclLevel, BatonError> {
     match s {
         "null" => Ok(AclLevel::Null),

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -299,11 +299,16 @@ fn fetch_replicates(
     let mut inp = new_query_inp();
     let inp_ref = unsafe { inp.assume_init_mut() };
 
+    // Naming inconsistency note: iRODS 4.3.5's bindings expose this set
+    // as a mix of long-form (COL_DATA_REPL_NUM) and short-form
+    // (COL_D_DATA_CHECKSUM / COL_D_RESC_NAME / COL_D_REPL_STATUS) — not a
+    // typo, that's actually how the headers are. Compiler "similar name"
+    // hints were the source of truth.
     add_select(inp_ref, ffi::COL_DATA_REPL_NUM as i32);
-    add_select(inp_ref, ffi::COL_DATA_CHECKSUM as i32);
+    add_select(inp_ref, ffi::COL_D_DATA_CHECKSUM as i32);
     add_select(inp_ref, ffi::COL_R_LOC as i32);
-    add_select(inp_ref, ffi::COL_DATA_RESC_NAME as i32);
-    add_select(inp_ref, ffi::COL_DATA_REPL_STATUS as i32);
+    add_select(inp_ref, ffi::COL_D_RESC_NAME as i32);
+    add_select(inp_ref, ffi::COL_D_REPL_STATUS as i32);
 
     add_where(
         inp_ref,

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -299,11 +299,11 @@ fn fetch_replicates(
     let mut inp = new_query_inp();
     let inp_ref = unsafe { inp.assume_init_mut() };
 
-    add_select(inp_ref, ffi::COL_D_REPL_NUM as i32);
-    add_select(inp_ref, ffi::COL_D_DATA_CHECKSUM as i32);
+    add_select(inp_ref, ffi::COL_DATA_REPL_NUM as i32);
+    add_select(inp_ref, ffi::COL_DATA_CHECKSUM as i32);
     add_select(inp_ref, ffi::COL_R_LOC as i32);
-    add_select(inp_ref, ffi::COL_D_RESC_NAME as i32);
-    add_select(inp_ref, ffi::COL_D_REPL_STATUS as i32);
+    add_select(inp_ref, ffi::COL_DATA_RESC_NAME as i32);
+    add_select(inp_ref, ffi::COL_DATA_REPL_STATUS as i32);
 
     add_where(
         inp_ref,

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -14,7 +14,7 @@ use std::mem::MaybeUninit;
 use crate::connection::RodsConnection;
 use crate::error::BatonError;
 use crate::ffi;
-use crate::types::{Acl, AclLevel, Avu, DataObject, Replicate, Target};
+use crate::types::{Acl, AclLevel, Avu, DataObject, Replicate, Target, Timestamp};
 
 /// Which optional fields the caller wants populated in the output.
 #[derive(Debug, Default, Clone, Copy)]
@@ -78,6 +78,14 @@ pub fn list_one(
     if opts.replicate {
         if let Target::DataObject(d) = &mut target {
             d.replicates = Some(fetch_replicates(conn, d)?);
+        }
+    }
+
+    if opts.timestamp {
+        let timestamps = fetch_timestamps(conn, &target)?;
+        match &mut target {
+            Target::DataObject(d) => d.timestamps = Some(timestamps),
+            Target::Collection(c) => c.timestamps = Some(timestamps),
         }
     }
 
@@ -345,6 +353,77 @@ fn fetch_replicates(
             })
         })
         .collect()
+}
+
+/// Fetch the create/modify timestamps for a target.
+///
+/// Each catalog row carries both timestamps for the same scope (per-replica
+/// for a data object, single per-collection). We fan out to two
+/// [`Timestamp`] entries per row — one with `created`, one with `modified`
+/// — so the JSON output matches baton's per-event shape.
+fn fetch_timestamps(
+    conn: &mut RodsConnection,
+    target: &Target,
+) -> Result<Vec<Timestamp>, BatonError> {
+    let mut inp = new_query_inp();
+    let inp_ref = unsafe { inp.assume_init_mut() };
+
+    let with_replicate = matches!(target, Target::DataObject(_));
+
+    match target {
+        Target::DataObject(d) => {
+            // Data object: per-replica timestamps. SELECT order matches the
+            // row indices we read out below.
+            add_select(inp_ref, ffi::COL_D_CREATE_TIME as i32);
+            add_select(inp_ref, ffi::COL_D_MODIFY_TIME as i32);
+            add_select(inp_ref, ffi::COL_DATA_REPL_NUM as i32);
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.collection)),
+            )?;
+            add_where(
+                inp_ref,
+                ffi::COL_DATA_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.data_object)),
+            )?;
+        }
+        Target::Collection(c) => {
+            add_select(inp_ref, ffi::COL_COLL_CREATE_TIME as i32);
+            add_select(inp_ref, ffi::COL_COLL_MODIFY_TIME as i32);
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&c.collection)),
+            )?;
+        }
+    }
+
+    let rows = run_query(conn, inp_ref)?;
+
+    let mut timestamps = Vec::with_capacity(rows.len() * 2);
+    for row in rows {
+        let created = row.first().cloned().unwrap_or_default();
+        let modified = row.get(1).cloned().unwrap_or_default();
+        let replicate = if with_replicate {
+            row.get(2)
+                .and_then(|s| s.parse::<u32>().ok())
+        } else {
+            None
+        };
+
+        timestamps.push(Timestamp {
+            created: Some(created),
+            modified: None,
+            replicate,
+        });
+        timestamps.push(Timestamp {
+            created: None,
+            modified: Some(modified),
+            replicate,
+        });
+    }
+    Ok(timestamps)
 }
 
 fn parse_acl_level(s: &str) -> Result<AclLevel, BatonError> {

--- a/src/operations/list.rs
+++ b/src/operations/list.rs
@@ -8,9 +8,13 @@
 //! `--checksum`. Metadata flags (`--avu`, `--acl`, `--replicate`,
 //! `--timestamp`) and `--contents` arrive in Sessions 3b / 3c respectively.
 
+use std::ffi::CString;
+use std::mem::MaybeUninit;
+
 use crate::connection::RodsConnection;
 use crate::error::BatonError;
-use crate::types::Target;
+use crate::ffi;
+use crate::types::{Avu, Target};
 
 /// Which optional fields the caller wants populated in the output.
 #[derive(Debug, Default, Clone, Copy)]
@@ -53,7 +57,150 @@ pub fn list_one(
         }
     }
 
+    if opts.avu {
+        let avus = fetch_avus(conn, &target)?;
+        match &mut target {
+            Target::DataObject(d) => d.avus = Some(avus),
+            Target::Collection(c) => c.avus = Some(avus),
+        }
+    }
+
     Ok(target)
+}
+
+// --- catalog query helpers ----------------------------------------------------
+
+/// Default `maxRows` for our catalog queries — picks up most realistic
+/// per-object metadata sets in one round trip; pagination via `query()`
+/// handles the rest transparently.
+const QUERY_PAGE_SIZE: i32 = 500;
+
+/// Escape single quotes for inclusion in a genQuery WHERE-clause literal.
+/// Paths and metadata values can legitimately contain `'`; the iRODS query
+/// parser accepts the SQL-style `''` doubled form.
+fn sql_escape(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+/// Initialise a zeroed `genQueryInp_t` with the standard page size.
+/// Caller is responsible for `clearGenQueryInp` after using it.
+fn new_query_inp() -> MaybeUninit<ffi::genQueryInp_t> {
+    let mut inp = MaybeUninit::<ffi::genQueryInp_t>::zeroed();
+    // SAFETY: the zeroed struct satisfies all field-init requirements;
+    // setting maxRows is the only mutation we need before query().
+    unsafe { inp.assume_init_mut().maxRows = QUERY_PAGE_SIZE };
+    inp
+}
+
+/// Add `col` to the SELECT list of `inp` (no aggregation).
+fn add_select(inp: &mut ffi::genQueryInp_t, col: i32) {
+    unsafe { ffi::addInxIval(&mut inp.selectInp, col, 0) };
+}
+
+/// Add a WHERE condition to `inp`. `condition` is the operator + literal
+/// the way iRODS's genQuery parser wants it, e.g. `"= '/testZone/home/irods'"`.
+fn add_where(
+    inp: &mut ffi::genQueryInp_t,
+    col: i32,
+    condition: &str,
+) -> Result<(), BatonError> {
+    let c = CString::new(condition).map_err(|_| BatonError {
+        code: -1,
+        message: "WHERE condition contains interior NUL".to_string(),
+    })?;
+    // iRODS's addInxVal strdup's the value, so it's safe to drop `c` here.
+    unsafe { ffi::addInxVal(&mut inp.sqlCondInp, col, c.as_ptr()) };
+    Ok(())
+}
+
+/// Run a populated input and always clear it before returning, regardless
+/// of whether the query succeeded — `clearGenQueryInp` frees the
+/// strdup'd condition / select buffers.
+fn run_query(
+    conn: &mut RodsConnection,
+    inp: &mut ffi::genQueryInp_t,
+) -> Result<Vec<Vec<String>>, BatonError> {
+    let result = conn.query(inp);
+    unsafe { ffi::clearGenQueryInp(inp) };
+    result
+}
+
+// --- per-flag fetchers --------------------------------------------------------
+
+/// Fetch the AVUs attached to a target.
+///
+/// Data objects use the `META_DATA_*` columns and need both
+/// `COLL_NAME` and `DATA_NAME` in the WHERE clause; collections use the
+/// `META_COLL_*` columns and only need `COLL_NAME`.
+fn fetch_avus(conn: &mut RodsConnection, target: &Target) -> Result<Vec<Avu>, BatonError> {
+    let mut inp = new_query_inp();
+    let inp_ref = unsafe { inp.assume_init_mut() };
+
+    let (col_attr, col_value, col_units) = match target {
+        Target::DataObject(_) => (
+            ffi::COL_META_DATA_ATTR_NAME as i32,
+            ffi::COL_META_DATA_ATTR_VALUE as i32,
+            ffi::COL_META_DATA_ATTR_UNITS as i32,
+        ),
+        Target::Collection(_) => (
+            ffi::COL_META_COLL_ATTR_NAME as i32,
+            ffi::COL_META_COLL_ATTR_VALUE as i32,
+            ffi::COL_META_COLL_ATTR_UNITS as i32,
+        ),
+    };
+    add_select(inp_ref, col_attr);
+    add_select(inp_ref, col_value);
+    add_select(inp_ref, col_units);
+
+    match target {
+        Target::DataObject(d) => {
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.collection)),
+            )?;
+            add_where(
+                inp_ref,
+                ffi::COL_DATA_NAME as i32,
+                &format!("= '{}'", sql_escape(&d.data_object)),
+            )?;
+        }
+        Target::Collection(c) => {
+            add_where(
+                inp_ref,
+                ffi::COL_COLL_NAME as i32,
+                &format!("= '{}'", sql_escape(&c.collection)),
+            )?;
+        }
+    }
+
+    let rows = run_query(conn, inp_ref)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            // Defensive .get/.cloned: rcGenQuery should always populate every
+            // selected column, but treating a missing column as empty string
+            // keeps the helper from panicking on an unexpectedly truncated
+            // row.
+            let attribute = row.first().cloned().unwrap_or_default();
+            let value = row.get(1).cloned().unwrap_or_default();
+            let units_raw = row.get(2).cloned().unwrap_or_default();
+            // iRODS returns an empty string for unitless AVUs; fold that
+            // back to None so the JSON output omits the `units` key
+            // (matches baton's behaviour).
+            let units = if units_raw.is_empty() {
+                None
+            } else {
+                Some(units_raw)
+            };
+            Avu {
+                attribute,
+                value,
+                units,
+            }
+        })
+        .collect())
 }
 
 /// Same as [`list_one`], but catches iRODS errors and emits the input

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -32,6 +32,69 @@ fn iput_with_checksum(local: &str, remote: &str) {
     assert!(status.success(), "iput -K {} {} failed", local, remote);
 }
 
+/// `imeta add <kind_flag> <path> <attr> <value> [units]`: attach an AVU.
+/// `kind_flag` is `-d` for data objects, `-C` for collections.
+fn imeta_add(
+    kind_flag: &str,
+    path: &str,
+    attr: &str,
+    value: &str,
+    units: Option<&str>,
+) {
+    let mut args: Vec<String> = vec![
+        "add".to_string(),
+        kind_flag.to_string(),
+        path.to_string(),
+        attr.to_string(),
+        value.to_string(),
+    ];
+    if let Some(u) = units {
+        args.push(u.to_string());
+    }
+    let status = Command::new("imeta")
+        .args(&args)
+        .status()
+        .expect("failed to spawn imeta");
+    assert!(status.success(), "imeta add {} {} failed", kind_flag, path);
+}
+
+/// `imeta rm <kind_flag> <path> <attr> <value> [units]`: best-effort remove
+/// of a previously-added AVU. Errors are swallowed because this runs from
+/// drop guards and the cleanup is idempotent.
+fn imeta_rm(kind_flag: &str, path: &str, attr: &str, value: &str, units: Option<&str>) {
+    let mut args: Vec<String> = vec![
+        "rm".to_string(),
+        kind_flag.to_string(),
+        path.to_string(),
+        attr.to_string(),
+        value.to_string(),
+    ];
+    if let Some(u) = units {
+        args.push(u.to_string());
+    }
+    let _ = Command::new("imeta").args(&args).status();
+}
+
+/// Drop guard for an AVU on a data object or collection.
+struct AvuCleanup {
+    kind_flag: &'static str,
+    path: String,
+    attr: String,
+    value: String,
+    units: Option<String>,
+}
+impl Drop for AvuCleanup {
+    fn drop(&mut self) {
+        imeta_rm(
+            self.kind_flag,
+            &self.path,
+            &self.attr,
+            &self.value,
+            self.units.as_deref(),
+        );
+    }
+}
+
 #[test]
 fn list_home_collection_returns_target_unchanged() {
     let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
@@ -154,6 +217,130 @@ fn list_data_object_without_flags_preserves_none_fields() {
     };
     assert_eq!(d.size, None, "size stays None when flag is off");
     assert_eq!(d.checksum, None, "checksum stays None when flag is off");
+}
+
+#[test]
+fn list_data_object_with_avus() {
+    let local = "/tmp/baton_rs_test_file_avus";
+    std::fs::write(local, b"avu test").expect("write");
+
+    let remote_coll = "/testZone/home/irods";
+    let data_object = "baton_rs_test_file_avus";
+    let remote = format!("{}/{}", remote_coll, data_object);
+    iput_with_checksum(local, &remote);
+    let _file_cleanup = IrodsCleanup(remote.clone());
+
+    // Stage two AVUs: one with units, one without. Different attribute
+    // names so order-of-removal in cleanup doesn't matter.
+    imeta_add("-d", &remote, "sample", "12345", Some("id"));
+    imeta_add("-d", &remote, "lane", "7", None);
+    let _avu1 = AvuCleanup {
+        kind_flag: "-d",
+        path: remote.clone(),
+        attr: "sample".to_string(),
+        value: "12345".to_string(),
+        units: Some("id".to_string()),
+    };
+    let _avu2 = AvuCleanup {
+        kind_flag: "-d",
+        path: remote.clone(),
+        attr: "lane".to_string(),
+        value: "7".to_string(),
+        units: None,
+    };
+
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::DataObject(DataObject {
+        collection: remote_coll.to_string(),
+        data_object: data_object.to_string(),
+        size: None,
+        checksum: None,
+        avus: None,
+        access: None,
+        replicates: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        avu: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let d = match result {
+        Target::DataObject(d) => d,
+        _ => panic!("expected DataObject"),
+    };
+    let avus = d.avus.as_ref().expect("avus populated");
+    assert_eq!(avus.len(), 2, "expected exactly the two staged AVUs, got {:?}", avus);
+
+    // Order of returned AVUs is iRODS-defined; assert by content rather
+    // than position.
+    let sample = avus
+        .iter()
+        .find(|a| a.attribute == "sample")
+        .expect("sample AVU present");
+    assert_eq!(sample.value, "12345");
+    assert_eq!(sample.units.as_deref(), Some("id"));
+
+    let lane = avus
+        .iter()
+        .find(|a| a.attribute == "lane")
+        .expect("lane AVU present");
+    assert_eq!(lane.value, "7");
+    assert_eq!(lane.units, None, "unitless AVU has units = None");
+}
+
+#[test]
+fn list_collection_with_avus() {
+    // Use a fresh sub-collection so any AVUs we add can't collide with
+    // unrelated tests in /testZone/home/irods. imkdir creates and irmdir
+    // (via IrodsCleanup => irm -f works on collections too) tears it down.
+    let test_coll = "/testZone/home/irods/baton_rs_avu_coll";
+    let _coll_cleanup = IrodsCleanup(test_coll.to_string());
+
+    let mkdir_status = Command::new("imkdir")
+        .args(["-p", test_coll])
+        .status()
+        .expect("failed to spawn imkdir");
+    assert!(mkdir_status.success(), "imkdir {} failed", test_coll);
+
+    imeta_add("-C", test_coll, "project", "baton-rs", None);
+    let _avu = AvuCleanup {
+        kind_flag: "-C",
+        path: test_coll.to_string(),
+        attr: "project".to_string(),
+        value: "baton-rs".to_string(),
+        units: None,
+    };
+
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::Collection(Collection {
+        collection: test_coll.to_string(),
+        avus: None,
+        access: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        avu: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let c = match result {
+        Target::Collection(c) => c,
+        _ => panic!("expected Collection"),
+    };
+    let avus = c.avus.as_ref().expect("avus populated");
+    assert_eq!(avus.len(), 1, "expected one AVU on the collection, got {:?}", avus);
+    assert_eq!(avus[0].attribute, "project");
+    assert_eq!(avus[0].value, "baton-rs");
+    assert_eq!(avus[0].units, None);
 }
 
 #[test]

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -424,6 +424,83 @@ fn list_collection_with_acl() {
 }
 
 #[test]
+fn list_data_object_with_replicate() {
+    let local = "/tmp/baton_rs_test_file_repl";
+    std::fs::write(local, b"replicate test").expect("write");
+
+    let remote_coll = "/testZone/home/irods";
+    let data_object = "baton_rs_test_file_repl";
+    let remote = format!("{}/{}", remote_coll, data_object);
+    iput_with_checksum(local, &remote);
+    let _cleanup = IrodsCleanup(remote);
+
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::DataObject(DataObject {
+        collection: remote_coll.to_string(),
+        data_object: data_object.to_string(),
+        size: None,
+        checksum: None,
+        avus: None,
+        access: None,
+        replicates: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        replicate: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let d = match result {
+        Target::DataObject(d) => d,
+        _ => panic!("expected DataObject"),
+    };
+    let replicates = d.replicates.as_ref().expect("replicates populated");
+    assert!(!replicates.is_empty(), "expected at least one replica");
+
+    // Find replica 0 — every iput'd object has at least this one. We
+    // don't pin specific resource / location values because they vary
+    // by server policy (replResc on this image, but other resources are
+    // possible elsewhere).
+    let r0 = replicates
+        .iter()
+        .find(|r| r.number == 0)
+        .expect("replica 0 present");
+    assert!(!r0.resource.is_empty(), "resource set");
+    assert!(!r0.location.is_empty(), "location set");
+    assert!(r0.valid, "replica 0 should be valid right after iput");
+}
+
+#[test]
+fn list_collection_replicate_flag_is_silently_ignored() {
+    // baton's --replicate is a no-op on collections; we mirror that.
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::Collection(Collection {
+        collection: "/testZone/home/irods".to_string(),
+        avus: None,
+        access: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        replicate: true,
+        ..Default::default()
+    };
+    // No panic, no error, nothing populated on the collection side.
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    match result {
+        Target::Collection(_) => {} // collections have no replicates field
+        _ => panic!("expected Collection"),
+    }
+}
+
+#[test]
 fn list_one_annotated_annotates_error_for_missing_path() {
     let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
     conn.login_from_auth_file().expect("login_from_auth_file");

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -397,7 +397,6 @@ fn list_collection_with_acl() {
     let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
     conn.login_from_auth_file().expect("login_from_auth_file");
 
-    // Home collection always has at least the owner with `own` access.
     let input = Target::Collection(Collection {
         collection: "/testZone/home/irods".to_string(),
         avus: None,
@@ -416,11 +415,19 @@ fn list_collection_with_acl() {
         _ => panic!("expected Collection"),
     };
     let access = c.access.as_ref().expect("access populated");
-    let owner_acl = access
-        .iter()
-        .find(|a| a.owner == "irods")
-        .expect("owner ACL present");
-    assert_eq!(owner_acl.level, AclLevel::Own);
+
+    // Whichever server-policy combination of (user, rodsadmin group, ...)
+    // owns the home collection, there must be at least one Own-level
+    // entry. The devcontainer image lists the `irods` user directly; the
+    // CI image lists only `rodsadmin` (with the user inheriting access
+    // through group membership). Don't pin a specific owner — assert the
+    // shape that actually matters for the catalog-query plumbing.
+    assert!(!access.is_empty(), "expected ACL entries on home collection");
+    assert!(
+        access.iter().any(|a| a.level == AclLevel::Own),
+        "expected at least one Own-level entry, got {:?}",
+        access
+    );
 }
 
 #[test]

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -501,6 +501,106 @@ fn list_collection_replicate_flag_is_silently_ignored() {
 }
 
 #[test]
+fn list_data_object_with_timestamp() {
+    let local = "/tmp/baton_rs_test_file_ts";
+    std::fs::write(local, b"timestamp test").expect("write");
+
+    let remote_coll = "/testZone/home/irods";
+    let data_object = "baton_rs_test_file_ts";
+    let remote = format!("{}/{}", remote_coll, data_object);
+    iput_with_checksum(local, &remote);
+    let _cleanup = IrodsCleanup(remote);
+
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::DataObject(DataObject {
+        collection: remote_coll.to_string(),
+        data_object: data_object.to_string(),
+        size: None,
+        checksum: None,
+        avus: None,
+        access: None,
+        replicates: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        timestamp: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let d = match result {
+        Target::DataObject(d) => d,
+        _ => panic!("expected DataObject"),
+    };
+    let timestamps = d.timestamps.as_ref().expect("timestamps populated");
+    // One replica → one created entry + one modified entry.
+    assert_eq!(timestamps.len(), 2, "got {:?}", timestamps);
+
+    // We don't assert exact values (iRODS returns padded epoch strings,
+    // and the actual time depends on when the test runs); we assert
+    // shape: each entry has exactly one of created/modified populated,
+    // and the replicate number is 0 for both.
+    let created = timestamps
+        .iter()
+        .find(|t| t.created.is_some())
+        .expect("created entry present");
+    assert_eq!(created.modified, None);
+    assert_eq!(created.replicate, Some(0));
+    assert!(
+        !created.created.as_ref().unwrap().is_empty(),
+        "created timestamp non-empty"
+    );
+
+    let modified = timestamps
+        .iter()
+        .find(|t| t.modified.is_some())
+        .expect("modified entry present");
+    assert_eq!(modified.created, None);
+    assert_eq!(modified.replicate, Some(0));
+    assert!(
+        !modified.modified.as_ref().unwrap().is_empty(),
+        "modified timestamp non-empty"
+    );
+}
+
+#[test]
+fn list_collection_with_timestamp() {
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::Collection(Collection {
+        collection: "/testZone/home/irods".to_string(),
+        avus: None,
+        access: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        timestamp: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let c = match result {
+        Target::Collection(c) => c,
+        _ => panic!("expected Collection"),
+    };
+    let timestamps = c.timestamps.as_ref().expect("timestamps populated");
+    assert_eq!(timestamps.len(), 2, "got {:?}", timestamps);
+
+    // Collections have no per-replica timestamps; the replicate field
+    // should be None on both entries.
+    for t in timestamps {
+        assert_eq!(t.replicate, None);
+    }
+    assert!(timestamps.iter().any(|t| t.created.is_some()));
+    assert!(timestamps.iter().any(|t| t.modified.is_some()));
+}
+
+#[test]
 fn list_one_annotated_annotates_error_for_missing_path() {
     let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
     conn.login_from_auth_file().expect("login_from_auth_file");

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -536,32 +536,39 @@ fn list_data_object_with_timestamp() {
         _ => panic!("expected DataObject"),
     };
     let timestamps = d.timestamps.as_ref().expect("timestamps populated");
-    // One replica → one created entry + one modified entry.
-    assert_eq!(timestamps.len(), 2, "got {:?}", timestamps);
 
-    // We don't assert exact values (iRODS returns padded epoch strings,
-    // and the actual time depends on when the test runs); we assert
-    // shape: each entry has exactly one of created/modified populated,
-    // and the replicate number is 0 for both.
-    let created = timestamps
+    // Each replica produces one `created` entry + one `modified` entry.
+    // The wtsi-npg dev image's default `replResc` keeps two replicas so
+    // we typically get four total, but other servers policy may differ —
+    // assert pair-shape rather than an exact count.
+    assert!(!timestamps.is_empty(), "at least one timestamp pair");
+    assert_eq!(
+        timestamps.len() % 2,
+        0,
+        "expected paired (created + modified) entries per replica, got {:?}",
+        timestamps
+    );
+
+    // Replica 0 always exists. Verify shape there: each Timestamp has
+    // exactly one of created/modified populated, value is non-empty,
+    // replicate number tags both.
+    let r0_created = timestamps
         .iter()
-        .find(|t| t.created.is_some())
-        .expect("created entry present");
-    assert_eq!(created.modified, None);
-    assert_eq!(created.replicate, Some(0));
+        .find(|t| t.replicate == Some(0) && t.created.is_some())
+        .expect("replica 0 created entry present");
+    assert_eq!(r0_created.modified, None);
     assert!(
-        !created.created.as_ref().unwrap().is_empty(),
+        !r0_created.created.as_ref().unwrap().is_empty(),
         "created timestamp non-empty"
     );
 
-    let modified = timestamps
+    let r0_modified = timestamps
         .iter()
-        .find(|t| t.modified.is_some())
-        .expect("modified entry present");
-    assert_eq!(modified.created, None);
-    assert_eq!(modified.replicate, Some(0));
+        .find(|t| t.replicate == Some(0) && t.modified.is_some())
+        .expect("replica 0 modified entry present");
+    assert_eq!(r0_modified.created, None);
     assert!(
-        !modified.modified.as_ref().unwrap().is_empty(),
+        !r0_modified.modified.as_ref().unwrap().is_empty(),
         "modified timestamp non-empty"
     );
 }

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 
 use baton_rs::connection::ObjType;
 use baton_rs::operations::list::{list_one, list_one_annotated, ListOptions};
-use baton_rs::types::{Collection, DataObject};
+use baton_rs::types::{AclLevel, Collection, DataObject};
 use baton_rs::{RodsConnection, Target};
 
 /// Drop-guard that removes a remote iRODS path via `irm -f` on Drop,
@@ -341,6 +341,86 @@ fn list_collection_with_avus() {
     assert_eq!(avus[0].attribute, "project");
     assert_eq!(avus[0].value, "baton-rs");
     assert_eq!(avus[0].units, None);
+}
+
+#[test]
+fn list_data_object_with_acl() {
+    let local = "/tmp/baton_rs_test_file_acl";
+    std::fs::write(local, b"acl test").expect("write");
+
+    let remote_coll = "/testZone/home/irods";
+    let data_object = "baton_rs_test_file_acl";
+    let remote = format!("{}/{}", remote_coll, data_object);
+    iput_with_checksum(local, &remote);
+    let _cleanup = IrodsCleanup(remote);
+
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    let input = Target::DataObject(DataObject {
+        collection: remote_coll.to_string(),
+        data_object: data_object.to_string(),
+        size: None,
+        checksum: None,
+        avus: None,
+        access: None,
+        replicates: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        acl: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let d = match result {
+        Target::DataObject(d) => d,
+        _ => panic!("expected DataObject"),
+    };
+    let access = d.access.as_ref().expect("access populated");
+    assert!(!access.is_empty(), "expected at least the owner ACL");
+
+    // Newly-iput data objects always have the calling user with `own`
+    // access. We assert on that — the rest of the ACL is server-policy
+    // dependent and not worth pinning here.
+    let owner_acl = access
+        .iter()
+        .find(|a| a.owner == "irods")
+        .expect("owner ACL present");
+    assert_eq!(owner_acl.level, AclLevel::Own);
+    assert_eq!(owner_acl.zone.as_deref(), Some("testZone"));
+}
+
+#[test]
+fn list_collection_with_acl() {
+    let mut conn = RodsConnection::connect_from_env().expect("connect_from_env");
+    conn.login_from_auth_file().expect("login_from_auth_file");
+
+    // Home collection always has at least the owner with `own` access.
+    let input = Target::Collection(Collection {
+        collection: "/testZone/home/irods".to_string(),
+        avus: None,
+        access: None,
+        timestamps: None,
+        error: None,
+    });
+
+    let opts = ListOptions {
+        acl: true,
+        ..Default::default()
+    };
+    let result = list_one(&mut conn, input, &opts).expect("list_one");
+    let c = match result {
+        Target::Collection(c) => c,
+        _ => panic!("expected Collection"),
+    };
+    let access = c.access.as_ref().expect("access populated");
+    let owner_acl = access
+        .iter()
+        .find(|a| a.owner == "irods")
+        .expect("owner ACL present");
+    assert_eq!(owner_acl.level, AclLevel::Own);
 }
 
 #[test]


### PR DESCRIPTION
Second of three branches for PLAN.md Session 3 (`baton-list`). Adds the four metadata flags that drive the iRODS catalog via `rcGenQuery`. `--contents` and the upstream baton-list compatibility check are Session 3c.

## Summary

- **`Cargo.toml`** unchanged; existing deps cover everything in this branch.
- **FFI expansion (`build.rs`)** — adds `rcGenQuery` + helpers (`addInxIval` / `addInxVal` / `clearGenQueryInp` / `freeGenQueryOut`), all five supporting types (`genQueryInp_t` / `genQueryOut_t` / `sqlResult_t` / `inxIvalPair_t` / `inxValPair_t`), and the `COL_*` family of catalog column constants. No new link libraries — `rcGenQuery` lives in `libirods_client`.
- **`RodsConnection::query`** (crate-internal) — runs a prepared `genQueryInp_t`, iterates `continueInx` pages, frees output, treats `CAT_NO_ROWS_FOUND` as an empty success rather than an error. The per-flag fetchers in `operations::list` build the input and surface typed wrappers to public callers.
- **Shared catalog-query helpers** in `operations/list.rs` — `new_query_inp` / `add_select` / `add_where` / `run_query` / `sql_escape`. Used by all four metadata fetchers.
- **`--avu`** — `META_DATA_*` for data objects, `META_COLL_*` for collections. Empty server-side units fold to `units: None`.
- **`--acl`** — selects user-name / user-zone columns alongside the access-name column; data-objects use `COL_USER_*` joined via `COL_DATA_ACCESS_NAME`, collections use `COL_COLL_USER_*` joined via `COL_COLL_ACCESS_NAME` (different join paths). `parse_acl_level` accepts both compact (`read`/`write`) and verbose (`read object`/`modify object`) iRODS forms.
- **`--replicate`** — data-object only (matches baton). `valid` derives from `COL_D_REPL_STATUS == "1"`. Naming inconsistency note: iRODS 4.3.5's bindings expose this set as a mix of long-form `COL_DATA_REPL_NUM` and short-form `COL_D_DATA_CHECKSUM` / `COL_D_RESC_NAME` / `COL_D_REPL_STATUS` — a comment at the call site warns future readers not to "tidy up" without checking the bindings first.
- **`--timestamp`** — applies to data objects (per-replica) and collections (single pair). Each row fans out to two `Timestamp` entries — one with `created`, one with `modified` — matching baton's per-event JSON shape.

## Commits (11)

| SHA | Message |
|---|---|
| `33fb008` | feat(ffi): allowlist rcGenQuery + genQuery types + COL_* column constants |
| `9a311f1` | fix(ffi): hardcode CAT_NO_ROWS_FOUND; cast clearGenQueryInp arg to void* |
| `310df1f` | feat(list): support --avu for data objects and collections |
| `6bdb9fb` | feat(list): support --acl for data objects and collections |
| `06a26ad` | feat(list): support --replicate for data objects |
| `a2c0d63` | fix(list): use COL_DATA_* (not COL_D_*) prefix for replicate columns |
| `99151dc` | fix(list): match the actual mixed COL_*/COL_D_* naming in iRODS 4.3.5 |
| `44845e4` | feat(list): support --timestamp for data objects and collections |
| `1f86f23` | fix(test): allow multi-replica setups in the timestamp test |
| `54ecab8` | fix(test): don't pin specific owner for the home-collection ACL test |
| `e328018` | fix(list): use collection-specific user columns for collection ACL query |

## Verified in devcontainer + CI

- `cargo test --lib` — new unit tests for `parse_acl_level` (compact + verbose forms, error on unknown) and `sql_escape` (single-quote doubling) all pass.
- `cargo test --test list` — 13 integration tests now: existing 5 from Session 3a, plus two each for AVU / ACL / replicate / timestamp on data objects and collections (where applicable). Setup uses `iput -K`, `imeta add -d`/`-C`, and `imkdir`; cleanup via `IrodsCleanup` and `AvuCleanup` drop guards.
- End-to-end smoke with all four metadata flags emits one line with `avus`, `access`, `replicates`, and `timestamps` arrays populated. Replica count varies by server policy (`replResc` here gives two replicas — handled).

## Surprises caught during the session

- `CAT_NO_ROWS_FOUND` didn't make it through bindgen even though `CAT_.*` is allowlisted — the constant lives behind a header `wrapper.h` doesn't reach. Hardcoded the well-known `-808000` value at the single callsite.
- `clearGenQueryInp` is declared with a generic `void *` parameter (it shares the signature with other `clearXxx` helpers); bindgen surfaces that faithfully and we cast through `*mut _`.
- iRODS 4.3.5 catalog-column naming is genuinely inconsistent between long (`COL_DATA_*`) and short (`COL_D_*`) forms within the same logical column set. Compiler "did you mean" suggestions were the source of truth.
- **Collection vs data-object ACL queries need different user-name columns.** `COL_USER_NAME` / `COL_USER_ZONE` join via the data-access path; on a collection, that yields zero rows even when explicit collection ACLs exist. `COL_COLL_USER_NAME` / `COL_COLL_USER_ZONE` are the right join columns for the collection path. The devcontainer happened to mask this; CI's cleaner state surfaced it. baton's own C source uses the same split.

## Not in this branch

- `--contents` and the mixed-item enum it needs — Session 3c.
- Compatibility test against upstream `baton-list` — Session 3c.
- Any C-shim consolidation of this expanded FFI surface — still planned for the dedicated mini-session between Sessions 4 and 5 (#9).

## Refs

Refs #14