### PR TITLE
Session 8b: rename Operation::Move → Mv, Remove → Rm

### DIFF
--- a/src/operations/baton_do.rs
+++ b/src/operations/baton_do.rs
@@ -159,7 +159,7 @@ fn dispatch_inner(
             let out = checksum::checksum_one_annotated(conn, target);
             split_result(out)
         }
-        Operation::Move => {
+        Operation::Mv => {
             let target = match expect_standard(&envelope.target) {
                 Ok(t) => t,
                 Err(err) => return (None, Some(err)),
@@ -179,7 +179,7 @@ fn dispatch_inner(
                 ),
             }
         }
-        Operation::Remove => {
+        Operation::Rm => {
             let target = match expect_standard(&envelope.target) {
                 Ok(t) => t,
                 Err(err) => return (None, Some(err)),

--- a/src/types.rs
+++ b/src/types.rs
@@ -453,6 +453,12 @@ pub struct MetaqueryInput {
 /// `baton-do`-only ones added in Session 7a (`checksum` / `move` /
 /// `remove` / `mkdir` / `rmdir`). The wire form is bare lowercase.
 ///
+/// `Mv` and `Rm` carry explicit `#[serde(rename = ...)]` attributes
+/// so the wire form stays `"move"` / `"remove"` while the Rust
+/// variant names follow the abbreviation pattern shared with
+/// `Mkdir` / `Rmdir` (the modules they dispatch into are also
+/// `mv` / `rm`).
+///
 /// Anything else on input → serde fails to deserialise; the binary
 /// surfaces it as a parse error per the upstream-mirroring drop
 /// (deviation tracked in #37).
@@ -466,8 +472,10 @@ pub enum Operation {
     Metamod,
     Metaquery,
     Checksum,
-    Move,
-    Remove,
+    #[serde(rename = "move")]
+    Mv,
+    #[serde(rename = "remove")]
+    Rm,
     Mkdir,
     Rmdir,
 }
@@ -1492,8 +1500,8 @@ mod tests {
             (r#""metamod""#, Operation::Metamod),
             (r#""metaquery""#, Operation::Metaquery),
             (r#""checksum""#, Operation::Checksum),
-            (r#""move""#, Operation::Move),
-            (r#""remove""#, Operation::Remove),
+            (r#""move""#, Operation::Mv),
+            (r#""remove""#, Operation::Rm),
             (r#""mkdir""#, Operation::Mkdir),
             (r#""rmdir""#, Operation::Rmdir),
         ] {

--- a/tests/baton_do_binary.rs
+++ b/tests/baton_do_binary.rs
@@ -553,7 +553,7 @@ fn binary_dispatches_rmdir() {
     assert!(!status.success(), "ils {} should fail after rmdir", coll);
 }
 
-// --- Operation::Remove ---------------------------------------------------
+// --- Operation::Rm -------------------------------------------------------
 
 #[test]
 fn binary_dispatches_remove() {
@@ -567,7 +567,7 @@ fn binary_dispatches_remove() {
     let _cleanup = IrodsCleanup(remote.clone());
 
     let env = BatonDoEnvelope::new_standard(
-        Operation::Remove,
+        Operation::Rm,
         data_object_target(TEST_COLL, &name),
         Arguments::default(),
     );
@@ -582,7 +582,7 @@ fn binary_dispatches_remove() {
     assert!(!status.success(), "ils {} should fail after rm", remote);
 }
 
-// --- Operation::Move -----------------------------------------------------
+// --- Operation::Mv -------------------------------------------------------
 
 #[test]
 fn binary_dispatches_move() {
@@ -599,7 +599,7 @@ fn binary_dispatches_move() {
     let mut args = Arguments::default();
     args.path = Some(dest_remote.clone());
     let env = BatonDoEnvelope::new_standard(
-        Operation::Move,
+        Operation::Mv,
         data_object_target(TEST_COLL, &src_name),
         args,
     );
@@ -975,7 +975,7 @@ fn boundary_path_with_spaces_through_checksum_and_rm() {
         args,
     );
     let rm_env = BatonDoEnvelope::new_standard(
-        Operation::Remove,
+        Operation::Rm,
         data_object_target(TEST_COLL, &name),
         Arguments::default(),
     );

--- a/tests/baton_do_dispatch.rs
+++ b/tests/baton_do_dispatch.rs
@@ -240,7 +240,7 @@ fn dispatch_move_requires_arguments_path() {
     conn.login_from_auth_file().expect("login_from_auth_file");
 
     let envelope = BatonDoEnvelope::new_standard(
-        Operation::Move,
+        Operation::Mv,
         data_object_target("/testZone/home/irods", "irrelevant"),
         Arguments::default(),
     );


### PR DESCRIPTION
## Summary

Mechanical refactor settling the variant ↔ module naming inconsistency flagged by Session 7's pre-PR audit. `Operation::Move` is renamed to `Operation::Mv`, `Operation::Remove` to `Operation::Rm`, matching the `Mkdir`/`Rmdir` abbreviation pattern already in the enum and the module names (`mv`, `rm`) they dispatch into.

## Wire-format compat preserved

The on-the-wire JSON stays `"operation": "move"` / `"remove"`. The enum's existing `#[serde(rename_all = "lowercase")]` derives wire names from variant names by lowercasing, so renaming `Move` → `Mv` without further action would have changed the wire form to `"mv"` and broken compat. The commit therefore adds explicit `#[serde(rename = "move")]` and `#[serde(rename = "remove")]` attributes on the renamed variants to preserve the existing wire form. (Correction note on #42 — the original issue body wrongly claimed those attributes were already in place from Session 7.)

## Scope

10 call sites updated across:

- `src/types.rs` — enum definition + the `operation_round_trip_all_eleven_variants` test mapping.
- `src/operations/baton_do.rs` — two dispatcher arms.
- `tests/baton_do_dispatch.rs` — one test.
- `tests/baton_do_binary.rs` — section comments + three test sites.

No behaviour change. Existing integration tests for `move` / `remove` continue to pass against live iRODS.

References #42, #39.

## Public Rust API impact

`Operation` is `pub` and re-exported via `baton_rs::types::*`, so the rename is technically a breaking change for any external Rust library consumer. baton-rs is pre-1.0 with no identified external Rust consumers — only the 7 in-tree binaries and integration tests. Acceptable cost for the consistency improvement.

## Test plan

- [x] `cargo build` clean in devcontainer.
- [x] `cargo test --lib` green (envelope + Operation round-trip tests still pass — wire format unchanged).
- [x] `cargo test --test '*'` green against live iRODS.
- [x] CI matrix (4.2.7 / 4.3.4 / 4.3.5) green.
- [x] No remaining `Operation::Move` / `Operation::Remove` references outside `#[serde(rename)]` attribute values (verified via `grep -rnE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)