### PR TITLE
ci: extract iRODS service-container setup into reusable workflow

### DIFF
--- a/.github/workflows/_irods-test.yml
+++ b/.github/workflows/_irods-test.yml
@@ -1,0 +1,78 @@
+name: "Run tests against iRODS (reusable)"
+
+# Reusable workflow that brings up an iRODS server in a service
+# container and runs an arbitrary build / test script inside a
+# build-image container that's networked to it.
+#
+# Callers parameterise:
+#   - which iRODS version to label the run with (display only)
+#   - which iRODS server image to start as the service container
+#   - which build image to run the test step in
+#   - which script the build image should execute
+#
+# The crate's own unit tests live in `unit-tests.yml`. Future
+# downstream-consumer compat workflows (partisan, extendo, …) call
+# this same reusable workflow with their language-appropriate
+# build image and a build-script that runs their test suite,
+# avoiding duplication of the iRODS service-container setup.
+
+on:
+  workflow_call:
+    inputs:
+      irods_version:
+        description: "iRODS version label, used in the job name."
+        required: true
+        type: string
+      server_image:
+        description: "Container image for the iRODS server service."
+        required: true
+        type: string
+      build_image:
+        description: "Container image for the build/test runner."
+        required: true
+        type: string
+      build_script:
+        description: "Workspace-relative path of the script the build image runs."
+        required: true
+        type: string
+      experimental:
+        description: "Treat job failure as soft (continue-on-error)."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  test:
+    name: "iRODS ${{ inputs.irods_version }}"
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.experimental }}
+
+    services:
+      irods-server:
+        image: ${{ inputs.server_image }}
+        ports:
+          - "1247:1247"
+          - "20000-20199:20000-20199"
+        volumes:
+          - /dev/shm:/dev/shm
+        options: >-
+          --health-cmd "nc -z -v localhost 1247"
+          --health-start-period 60s
+          --health-interval 10s
+          --health-timeout 20s
+          --health-retries 6
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Build and test"
+        uses: wtsi-npg/build-irods-client-action@v1.1.1
+        with:
+          build-image: ${{ inputs.build_image }}
+          build-script: ${{ inputs.build_script }}
+          docker-network: ${{ job.services.irods-server.network }}
+
+      - name: "Show test log"
+        if: ${{ failure() }}
+        run: find "$GITHUB_WORKSPACE" -name "*.log" -exec cat {} \;

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,60 +1,35 @@
 name: "Unit tests"
 on: [push, pull_request]
 
+# Per-iRODS-version unit-test runs. The actual heavy lifting (iRODS
+# server service container + build container running cargo test) lives
+# in the reusable workflow `_irods-test.yml` so future compat workflows
+# (partisan, extendo, …) can hit the same plumbing with their own
+# build-image / build-script.
+#
+# 4.2.7 was marked experimental during Sessions 2–4 because its Ubuntu
+# 16.04 base ships libclang 3.8, which modern bindgen / clang-sys
+# cannot run on (they require libclang ≥ 5.0). Session 4.5 (issue #9)
+# replaced bindgen with a hand-written FFI mirror of `shim/ffi_shim.h`
+# in `src/ffi.rs`, dropping the libclang dependency entirely. 4.2.7
+# is back to strict mode alongside the 4.3.x matrix entries.
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
-
+  test:
     strategy:
       matrix:
         include:
-          # 4.2.7 was marked experimental during Sessions 2–4 because its
-          # Ubuntu 16.04 base ships libclang 3.8, which modern bindgen /
-          # clang-sys cannot run on (they require libclang ≥ 5.0).
-          # Session 4.5 (issue #9) replaced bindgen with a hand-written
-          # FFI mirror of `shim/ffi_shim.h` in `src/ffi.rs`, dropping the
-          # libclang dependency entirely. 4.2.7 is back to strict mode
-          # alongside the 4.3.x matrix entries.
           - irods: "4.2.7"
             build_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-dev-4.2.7:latest"
             server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
-            experimental: false
           - irods: "4.3.4"
             build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.4:latest"
             server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.4:latest"
-            experimental: false
           - irods: "4.3.5"
             build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.5:latest"
             server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.5:latest"
-            experimental: false
-
-    services:
-      irods-server:
-        image: ${{ matrix.server_image }}
-        ports:
-          - "1247:1247"
-          - "20000-20199:20000-20199"
-        volumes:
-          - /dev/shm:/dev/shm
-        options: >-
-          --health-cmd "nc -z -v localhost 1247"
-          --health-start-period 60s
-          --health-interval 10s
-          --health-timeout 20s
-          --health-retries 6
-
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v6
-
-      - name: "Build and test"
-        uses: wtsi-npg/build-irods-client-action@v1.1.1
-        with:
-          build-image: ${{ matrix.build_image }}
-          build-script: docker/build.sh
-          docker-network: ${{ job.services.irods-server.network }}
-
-      - name: "Show test log"
-        if: ${{ failure() }}
-        run: find "$GITHUB_WORKSPACE" -name "*.log" -exec cat {} \;
+    uses: ./.github/workflows/_irods-test.yml
+    with:
+      irods_version: ${{ matrix.irods }}
+      server_image: ${{ matrix.server_image }}
+      build_image: ${{ matrix.build_image }}
+      build_script: docker/build.sh


### PR DESCRIPTION
## Summary

Splits the iRODS bootstrap out of \`unit-tests.yml\` into a reusable workflow \`_irods-test.yml\` (\`on: workflow_call\`) so future downstream-consumer compat workflows (partisan, extendo, …) can reuse the service-container plumbing without copy-pasting it.

Composite actions can't define \`services:\`, which is the actual reusable bit (the iRODS server container). A reusable workflow is the right primitive here: each compat workflow declares its own matrix (potentially with a different iRODS-version subset, different language toolchain) and calls \`_irods-test.yml\` with its language-appropriate \`build_image\` + \`build_script\`.

## What's inside the reusable workflow

- iRODS server as a service container (port 1247, health check, \`/dev/shm\` volume) — image picked by the caller's matrix
- \`actions/checkout@v6\`
- \`wtsi-npg/build-irods-client-action@v1.1.1\` (parameterised by \`build_image\` + \`build_script\`)
- Tail any \`*.log\` on failure

Inputs:
- \`irods_version\` — label only, used in the resolved job name
- \`server_image\` — ghcr image for the iRODS server service
- \`build_image\` — ghcr image for the build/test runner
- \`build_script\` — workspace-relative path the build image runs
- \`experimental\` — optional, defaults false; maps to \`continue-on-error\`

## What's left in \`unit-tests.yml\`

The 3-version matrix (4.2.7 / 4.3.4 / 4.3.5) and a single \`uses:\` line. 64 → 36 lines.

## Behavioural notes for reviewers

- **Job name renamed \`build\` → \`test\`.** Status-check names in the Checks UI shift anyway because of the reusable-workflow indirection (\`Unit tests / test (...) / iRODS X.Y.Z\` rather than \`Unit tests / build (X.Y.Z)\`). Branch-protection rules referencing the old names will need updating.
- **\`experimental: false\` dropped from each matrix entry** — it was a no-op since Session 4.5 lifted libclang's blocker on 4.2.7. The reusable workflow keeps \`experimental\` as an optional input defaulting to false for future compat-target use.

## Validation

CI on this branch is green across all three iRODS versions — the refactor preserves matrix coverage.

## References

Refs #39 (Session 8 prep for compat workflows in 8f).

## Test plan

- [x] CI matrix runs on 4.2.7 / 4.3.4 / 4.3.5 — green
- [x] No code changes (workflow YAML only)
- [ ] Branch protection rules updated post-merge if previously pinned to \`Unit tests / build (...)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)