### PR TITLE
fix(put): use md5::Context::finalize, compute deprecated in 0.8

### DIFF
--- a/src/operations/put.rs
+++ b/src/operations/put.rs
@@ -136,9 +136,10 @@ pub fn put_one(
         // explicitly via `ChecksumOptions`.
         let server_chksum = conn.checksum_data_object(&path, 0)?;
         if let Some(ctx) = hash {
-            // `ctx.compute()` consumes the context and returns a
+            // `ctx.finalize()` consumes the context and returns a
             // Digest that formats as 32 lowercase hex via {:x}.
-            let client_hex = format!("{:x}", ctx.compute());
+            // (Renamed from `compute()` in md5 0.8 — bumped via #46.)
+            let client_hex = format!("{:x}", ctx.finalize());
             // verify_checksum returns Err on mismatch; the caller
             // (put_one_annotated, in the binary's NDJSON loop)
             // surfaces it as an in-band annotation. The mismatched


### PR DESCRIPTION
## Summary

Clears the deprecation warning introduced when dependabot bumped \`md5\` from 0.7 → 0.8 in #46:

\`\`\`
warning: use of deprecated method \`md5::Context::compute\`: Use \`finalize\`.
   --> src/operations/put.rs:136:50
    |
136 |             let client_hex = format!("{:x}", ctx.compute());
    |                                                  ^^^^^^^
\`\`\`

The two methods are behaviourally identical — both consume \`self\` and return the same \`Digest\` value with the same \`{:x}\` formatting (32 lowercase hex). Pure rename, no behavioural change to the \`--verify\` digest path.

## Diff

3 lines: the call site (\`compute()\` → \`finalize()\`) plus a one-line comment refresh noting the 0.8 rename.

## References

Closes #48.

## Test plan

- [x] CI matrix runs on 4.2.7 / 4.3.4 / 4.3.5 — green
- [x] Existing \`tests/put.rs\` \`--verify\` tests still pass under the renamed call

🤖 Generated with [Claude Code](https://claude.com/claude-code)