### PR TITLE
test(baton-do): pin CRLF line-ending support + document matrix

### DIFF
--- a/src/bin/baton-do.rs
+++ b/src/bin/baton-do.rs
@@ -166,6 +166,28 @@ fn open_input(path: Option<&PathBuf>) -> Result<Box<dyn BufRead>> {
 /// also doesn't send malformed JSON, so this fallback only
 /// affects malformed-without-delimiter input (which can't be
 /// recovered from).
+///
+/// ## Line-ending support
+///
+/// The reader's re-sync is keyed on `\n` (LF). This handles the
+/// two line endings encountered in practice:
+///
+/// - **Unix LF (`\n`):** direct match — the canonical case.
+/// - **Windows CRLF (`\r\n`):** also handled. JSON's grammar
+///   (RFC 8259) treats `\r` as whitespace, so serde_json skips a
+///   leading `\r` between values; on the error path,
+///   `drain(..=nl_pos)` is inclusive and a `\r` immediately
+///   before `\n` sits at `nl_pos - 1`, so it's dropped along
+///   with the `\n`. No special handling required.
+/// - **Pre-OS-X Mac CR-only (`\r`)** is **not** supported. Apple
+///   dropped this convention in 2001; if it ever resurfaces,
+///   adding `\r` as a sync token in `advance_past_newline` is
+///   the smallest possible patch. Adding the support
+///   pre-emptively is over-engineering for an extinct platform.
+///
+/// `tests/baton_do_binary.rs::parse_failure_with_crlf_terminator_re_syncs`
+/// pins the CRLF behaviour explicitly so a future refactor can't
+/// silently regress it.
 struct StreamingEnvelopeReader<R: BufRead> {
     reader: R,
     buf: Vec<u8>,

--- a/tests/baton_do_binary.rs
+++ b/tests/baton_do_binary.rs
@@ -825,6 +825,109 @@ fn parse_failure_with_no_newline_terminates_stream() {
 }
 
 #[test]
+fn back_to_back_envelopes_with_crlf_terminators_round_trip() {
+    // Pins Windows-style CRLF (`\r\n`) handling for the streaming
+    // reader. The `\r` between envelopes is JSON whitespace per
+    // RFC 8259, so serde_json skips it; the inclusive
+    // `drain(..=nl_pos)` in `advance_past_newline` would also
+    // strip an adjacent `\r` if it had to fire. This test pins
+    // the happy-path CRLF behaviour so a future refactor can't
+    // silently regress baton-rs on Windows-authored input.
+    let local = "/tmp/baton_rs_bin_crlf_src";
+    std::fs::write(local, b"binary crlf").expect("write");
+    let name = unique_name("baton_rs_bin_crlf");
+    let remote = format!("{}/{}", TEST_COLL, name);
+    iput(local, &remote);
+    let _cleanup = IrodsCleanup(remote);
+
+    let env1 = BatonDoEnvelope::new_standard(
+        Operation::List,
+        data_object_target(TEST_COLL, &name),
+        Arguments::default(),
+    );
+    let env2 = BatonDoEnvelope::new_standard(
+        Operation::List,
+        data_object_target(TEST_COLL, &name),
+        Arguments::default(),
+    );
+    let s1 = serde_json::to_string(&env1).expect("serialise env1");
+    let s2 = serde_json::to_string(&env2).expect("serialise env2");
+    // Join with CRLF and terminate with CRLF — the shape Windows
+    // text editors and PowerShell pipelines emit by default.
+    let input = format!("{s1}\r\n{s2}\r\n");
+    assert!(
+        input.contains("\r\n"),
+        "test input must contain CRLF to exercise the Windows-style path"
+    );
+
+    let output = run_baton_do(&[], &input);
+    assert_success_exit(&output);
+
+    let outputs = parse_outputs(&stdout_str(&output));
+    assert_eq!(
+        outputs.len(),
+        2,
+        "expected 2 output lines for 2 CRLF-separated envelopes"
+    );
+    for (i, o) in outputs.iter().enumerate() {
+        assert!(
+            o.error.is_none(),
+            "record {}: unexpected error: {:?}",
+            i,
+            o.error
+        );
+    }
+}
+
+#[test]
+fn parse_failure_with_crlf_terminator_re_syncs() {
+    // Belt-and-braces for the doc-comment claim: a malformed line
+    // followed by `\r\n` then a valid envelope should still
+    // re-sync. The `drain(..=nl_pos)` in `advance_past_newline`
+    // covers the `\r` immediately preceding the `\n`, so the
+    // residual buffer doesn't start with a stray `\r` that
+    // serde_json would have to skip as whitespace anyway.
+    let local = "/tmp/baton_rs_bin_crlf_recover_src";
+    std::fs::write(local, b"binary crlf recover").expect("write");
+    let name = unique_name("baton_rs_bin_crlf_recover");
+    let remote = format!("{}/{}", TEST_COLL, name);
+    iput(local, &remote);
+    let _cleanup = IrodsCleanup(remote);
+
+    let good = serde_json::to_string(&BatonDoEnvelope::new_standard(
+        Operation::List,
+        data_object_target(TEST_COLL, &name),
+        Arguments::default(),
+    ))
+    .expect("serialise good envelope");
+    let input = format!("not-json\r\n{good}\r\n");
+
+    let output = run_baton_do(&[], &input);
+    assert!(
+        !output.status.success(),
+        "parse failure should produce non-zero exit",
+    );
+
+    let lines = parse_value_lines(&stdout_str(&output));
+    assert_eq!(
+        lines.len(),
+        2,
+        "one error line + one list line under CRLF: {:?}",
+        lines
+    );
+    assert!(
+        lines[0].get("error").is_some(),
+        "first line should be a stand-alone error: {}",
+        lines[0],
+    );
+    assert!(
+        lines[1].get("operation").is_some(),
+        "second line should be a normal output envelope: {}",
+        lines[1],
+    );
+}
+
+#[test]
 fn file_arg_reads_envelopes_from_disk() {
     // Same test as the list smoke, but inputs come from --file
     // instead of stdin.


### PR DESCRIPTION
**Stacked on top of #62 (\`fix/streaming-json-stdin\`).** GitHub will auto-redirect the base to \`main\` once that PR squash-merges and its branch is deleted.

Pure documentation + regression test work. No code changes — pins behaviour that already works as a side-effect of how the hybrid reader and JSON whitespace rules compose.

## What changes

1. **Doc-comment update on \`StreamingEnvelopeReader\`** (\`src/bin/baton-do.rs\`) spells out the line-ending support matrix:

   - **Unix LF (\`\\n\`)**: supported (canonical).
   - **Windows CRLF (\`\\r\\n\`)**: supported. JSON treats \`\\r\` as whitespace per RFC 8259, so serde_json skips a leading \`\\r\` between values; on the error path, \`drain(..=nl_pos)\` is inclusive and a \`\\r\` immediately preceding \`\\n\` is dropped along with it.
   - **Pre-OS-X Mac CR-only (\`\\r\`)**: NOT supported. Apple dropped this convention in 2001; if it ever resurfaces, adding \`\\r\` as a sync token in \`advance_past_newline\` is a small patch. Adding it pre-emptively would be over-engineering.

2. **Two new integration tests** (\`tests/baton_do_binary.rs\`):

   - \`back_to_back_envelopes_with_crlf_terminators_round_trip\` — happy-path CRLF: two valid envelopes joined and terminated with \`\\r\\n\` parse cleanly into two outputs.
   - \`parse_failure_with_crlf_terminator_re_syncs\` — error-path CRLF: malformed line followed by \`\\r\\n\` and a valid envelope produces an error annotation followed by the list result, just like the LF version of the same test.

## Why a separate PR

The streaming-fix PR (#62) is functional change with broad surface; this is regression coverage for an edge case. Reviewing them as separate units keeps the streaming-fix diff focused on the bug fix.

## Test plan

- [x] CI matrix runs on 4.2.7 / 4.3.4 / 4.3.5 (after #62 merges)
- [x] Two new integration tests pass against the hybrid reader from #62
- [x] No code changes — only docs + tests

## References

- Stacked on #62 (\`fix/streaming-json-stdin\`)
- Refs #60, #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)