### PR TITLE
ci(partisan): mark informational long-term + enable full iRODS matrix

### DIFF
--- a/.github/workflows/partisan-tests.yml
+++ b/.github/workflows/partisan-tests.yml
@@ -26,9 +26,12 @@ on:
 # duplicate the ~15-line iRODS service-container block to keep the
 # reusable workflow uncomplicated.
 #
-# Matrix-shaped for the same 4.2.7 / 4.3.4 / 4.3.5 trio as
-# `unit-tests.yml`, but only 4.3.5 is enabled today. Uncomment the
-# other entries once partisan is stable on 4.3.5.
+# Matrix runs partisan against 4.3.4 / 4.3.5. iRODS 4.2.7 is
+# intentionally excluded: its build image is Ubuntu 16.04, whose
+# stock OpenSSL is too old (1.0.2) for the Python 3.12 pyenv
+# install partisan requires (`_ssl` extension needs OpenSSL ≥
+# 1.1.1). `unit-tests.yml` still covers 4.2.7 directly — no
+# Python involved on that path.
 #
 # The job is intentionally **informational long-term**
 # (`continue-on-error: true`): partisan is a downstream consumer
@@ -49,12 +52,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - irods: "4.2.7"
-          #   build_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-dev-4.2.7:latest"
-          #   server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
-          # - irods: "4.3.4"
-          #   build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.4:latest"
-          #   server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.4:latest"
+          # iRODS 4.2.7 deliberately omitted — Ubuntu 16.04 base
+          # image ships OpenSSL 1.0.2, which can't build the
+          # Python 3.12 `_ssl` extension partisan needs. See the
+          # header comment.
+          - irods: "4.3.4"
+            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.4:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.4:latest"
           - irods: "4.3.5"
             build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.5:latest"
             server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.5:latest"

--- a/.github/workflows/partisan-tests.yml
+++ b/.github/workflows/partisan-tests.yml
@@ -28,11 +28,16 @@ on:
 #
 # Matrix-shaped for the same 4.2.7 / 4.3.4 / 4.3.5 trio as
 # `unit-tests.yml`, but only 4.3.5 is enabled today. Uncomment the
-# other entries once partisan is stable on 4.3.5. The job is
-# informational (`continue-on-error: true`) — cluster E from #57
-# still fails `test_verify_checksum_good` and we don't want that
-# blocking unrelated PRs. Flip to gating once `test_irods.py` is
-# fully green.
+# other entries once partisan is stable on 4.3.5.
+#
+# The job is intentionally **informational long-term**
+# (`continue-on-error: true`): partisan is a downstream consumer
+# pinned to a single SHA, so its tests carry information about
+# wire-compat regressions but shouldn't gate merges on the
+# baton-rs side — schema drift, partisan-pin bumps, or upstream
+# iRODS quirks would all surface here as "fails" the baton-rs
+# author can't fix in their own PR. Treat the partisan job as a
+# signal to investigate, not a merge blocker.
 #
 # Tracks #39 (Session 8), #57 (partisan recon).
 jobs:


### PR DESCRIPTION
## Summary

Two follow-ups to the partisan compatibility workflow merged in #72, plus a fix discovered during this PR's own CI run:

- **`202840e`** — flip the workflow's header comment from "flip to gating once `test_irods.py` is fully green" to "informational long-term". Partisan is a downstream consumer pinned to a single SHA, so its outcome carries information about wire-compat regressions but shouldn't gate baton-rs merges — partisan-pin bumps, schema drift, or upstream iRODS quirks would otherwise fail PRs the baton-rs author can't fix in their own work.

- **`93279c2`** — enable the 4.3.4 matrix entry (originally commented out alongside 4.2.7 during the partisan recon iteration).

- **`66b6ff5`** — exclude **iRODS 4.2.7** from the partisan matrix. CI on the enabled-everything version of this PR failed building Python 3.12 via pyenv on the 4.2.7 build image (Ubuntu 16.04, OpenSSL 1.0.2 — Python 3.12's `_ssl` requires OpenSSL ≥ 1.1.1). `unit-tests.yml` still covers 4.2.7 against baton-rs directly, so we keep iRODS 4.2.7 coverage overall — just not the partisan-compat dimension on Ubuntu 16.04. Documented in a short comment next to the matrix.

## Test plan

- [x] First push: 4.2.7 leg failed at Python build (root cause for `66b6ff5`)
- [x] Next push: workflow runs with two matrix legs (4.3.4 / 4.3.5)
- [x] Each leg reports independently — a failure on one doesn't fail the workflow as a whole (per `continue-on-error: true`)
- [x] No regression in the unit-tests workflow (still runs all three iRODS versions)

## Refs

- #72 — original partisan workflow merge (the pattern this PR finalises)
- #39 — Session 8 umbrella (closed; this PR is policy cleanup, not new scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)