### PR TITLE
chore(extendo-pin): pin to v3.1.0 release

### DIFF
--- a/.github/scripts/extendo-pin
+++ b/.github/scripts/extendo-pin
@@ -3,5 +3,6 @@
 # pull a newer extendo into the compat suite. The script ignores
 # lines starting with '#' so this header is fine.
 #
-# Recon context lives in issue #76.
-9b358660e453d2b9e1ba27a387bb5c0a412a8fa6
+# Currently pinned to extendo's v3.1.0 release tag. Recon context
+# lives in issue #76.
+b24b63cce5cd730533c77747d9b55db87fbd68fd


### PR DESCRIPTION
## Summary

Move the extendo pin from `9b358660` (extendo's latest tagged release (`v3.1.0`).

## Why this PR is against `feat/extendo-ci`

`.github/scripts/extendo-pin` only exists on `feat/extendo-ci`, not on `main`. Targeting `feat/extendo-ci` keeps this change a clean one-commit diff that lands together with the workflow when #76 merges.

## Effect

Bumping the pin invalidates the workflow's Go-cache key (`hashFiles('.github/scripts/extendo-pin')`), so the next run on `feat/extendo-ci` rebuilds the cache against v3.1.0.

## Refs

- Issue #76 — extendo compatibility workflow
- extendo v3.1.0 tag: https://github.com/wtsi-npg/extendo/releases/tag/v3.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)