### PR TITLE
ci(extendo): add informational workflow for extendo Ginkgo suite

### DIFF
--- a/.github/scripts/extendo-pin
+++ b/.github/scripts/extendo-pin
@@ -3,5 +3,6 @@
 # pull a newer extendo into the compat suite. The script ignores
 # lines starting with '#' so this header is fine.
 #
-# Recon context lives in issue #76.
-9b358660e453d2b9e1ba27a387bb5c0a412a8fa6
+# Currently pinned to extendo's v3.1.0 release tag. Recon context
+# lives in issue #76.
+b24b63cce5cd730533c77747d9b55db87fbd68fd

--- a/.github/scripts/extendo-pin
+++ b/.github/scripts/extendo-pin
@@ -1,0 +1,7 @@
+# Extendo commit consumed by .github/scripts/test-extendo.sh via
+# .github/workflows/extendo-tests.yml. Bump this single SHA to
+# pull a newer extendo into the compat suite. The script ignores
+# lines starting with '#' so this header is fine.
+#
+# Recon context lives in issue #76.
+9b358660e453d2b9e1ba27a387bb5c0a412a8fa6

--- a/.github/scripts/test-extendo.sh
+++ b/.github/scripts/test-extendo.sh
@@ -120,7 +120,12 @@ go install github.com/onsi/ginkgo/v2/ginkgo
 which baton-do
 baton-do --version
 
-# `ginkgo -r --race` mirrors extendo's own `make test` target.
-# -r recursively walks the test suites; --race enables the Go
-# race detector to catch any goroutine-related regressions.
-ginkgo -r --race
+# Mirrors extendo's own `make test` target plus a verbosity bump
+# for CI logs:
+#   -r        recursively walk test suites
+#   --race    enable the Go race detector
+#   -v        print each spec name as it runs (default is a
+#             dot-per-test summary, which makes a hang invisible
+#             — `Random Seed: ... Will run N of N specs` is the
+#             last thing you see before stdout goes quiet)
+ginkgo -r --race -v

--- a/.github/scripts/test-extendo.sh
+++ b/.github/scripts/test-extendo.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Build baton-rs and run extendo's Ginkgo suite against it.
+# Mirrors `docker/build.sh` for the Rust + iRODS-client bootstrap,
+# then layers on a Go toolchain (extendo's preferred install
+# path — see `extendo/Dockerfile.dev` at the pinned commit).
+# Wired up by `.github/workflows/extendo-tests.yml`.
+#
+# Lives under `.github/scripts/` (not `docker/`) because it's
+# CI-only — `docker/` is reserved for assets that produce
+# shippable images.
+#
+# The Go install + GOPATH live at `$PWD/.go-cache/` so the
+# calling workflow can persist them via `actions/cache@v4` keyed
+# off this script + `.github/scripts/extendo-pin`. First cold
+# run downloads the Go tarball + ginkgo + module deps; subsequent
+# warm runs skip straight to the test step.
+#
+# Extendo commit comes from `.github/scripts/extendo-pin` —
+# easier to bump than a constant here, and lets the workflow's
+# cache key invalidate automatically when we move forward. Recon
+# context lives in issue #76.
+
+# Go version — keep in step with extendo's `go.mod` toolchain
+# line. Go's tarball is statically linked; works on the Ubuntu
+# 16.04 build image used for the iRODS 4.2.7 leg (unlike pyenv,
+# which couldn't build Python 3.12's `_ssl` against the old
+# OpenSSL there).
+GO_VERSION="1.24.1"
+EXTENDO_PIN_FILE="${EXTENDO_PIN_FILE:-.github/scripts/extendo-pin}"
+EXTENDO_REPO="https://github.com/wtsi-npg/extendo.git"
+
+# Parse the pin file: skip blank / comment lines, take the first
+# remaining token. Tolerates the header comment block at the top.
+EXTENDO_COMMIT="$(
+    grep -v '^[[:space:]]*\(#\|$\)' "$EXTENDO_PIN_FILE" \
+        | head -n1 \
+        | tr -d '[:space:]'
+)"
+if [[ -z "$EXTENDO_COMMIT" ]]; then
+    echo "no extendo commit in $EXTENDO_PIN_FILE" >&2
+    exit 1
+fi
+
+# Install Rust (same shape as docker/build.sh).
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --no-modify-path
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Configure iRODS client — same shape as docker/build.sh (see
+# that file for the MD5 default-hash-scheme rationale).
+# Duplication is intentional: keeps this script self-contained
+# so the unit-tests pipeline doesn't need to evolve in lockstep
+# with extendo's needs.
+export HOME="${HOME:-/root}"
+mkdir -p "$HOME/.irods"
+cat > "$HOME/.irods/irods_environment.json" << 'EOF'
+{
+  "irods_host": "irods-server",
+  "irods_port": 1247,
+  "irods_user_name": "irods",
+  "irods_zone_name": "testZone",
+  "irods_home": "/testZone/home/irods",
+  "irods_default_resource": "replResc",
+  "irods_default_hash_scheme": "MD5"
+}
+EOF
+nc -z -v irods-server 1247
+echo "irods" | script -q -c "iinit" /dev/null
+
+# Build baton-rs binaries and put them on PATH so extendo's
+# subprocess.run-equivalents (`exec.Command("baton-do", ...)`)
+# find the right thing.
+cargo build --release
+export PATH="$PWD/target/release:$PATH"
+
+# Extendo, like partisan, parses `baton-do --version` to
+# determine the wire shape. Switch baton-rs into strict-compat
+# mode so it reports the upstream baton release we target wire
+# parity with (see SESSIONS.md, #58).
+export STRICT_BATON_COMPAT=1
+
+# Workspace-relative Go root + GOPATH so the calling workflow's
+# `actions/cache@v4` step can persist them across runs.
+export GO_CACHE_ROOT="$PWD/.go-cache"
+export GOROOT="$GO_CACHE_ROOT/go"
+export GOPATH="$GO_CACHE_ROOT/gopath"
+export PATH="$GOROOT/bin:$GOPATH/bin:$PATH"
+
+# Install gate: skip the Go tarball download + extract if a
+# matching toolchain is already in place (warm cache).
+if [[ ! -x "$GOROOT/bin/go" ]] || [[ "$(${GOROOT}/bin/go version 2>/dev/null | awk '{print $3}')" != "go${GO_VERSION}" ]]; then
+    rm -rf "$GOROOT"
+    mkdir -p "$GO_CACHE_ROOT"
+    curl -sSL -o "$GO_CACHE_ROOT/go.tar.gz" \
+        "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+    tar -C "$GO_CACHE_ROOT" -xzf "$GO_CACHE_ROOT/go.tar.gz"
+    rm "$GO_CACHE_ROOT/go.tar.gz"
+fi
+mkdir -p "$GOPATH"
+
+go version
+
+# Fetch extendo at the pinned commit and build / test from there.
+git clone "$EXTENDO_REPO" /tmp/extendo
+git -C /tmp/extendo checkout "$EXTENDO_COMMIT"
+
+# Resolve module deps + install ginkgo. `go install` honours the
+# GOPATH we set above, so the ginkgo binary lands at
+# `$GOPATH/bin/ginkgo` and gets re-used from cache on subsequent
+# runs.
+cd /tmp/extendo
+go mod download
+go install github.com/onsi/ginkgo/v2/ginkgo
+
+# Smoke-check baton-rs is on the subprocess search path before
+# extendo tries to spawn it. A missing binary here is much
+# easier to debug than an exec error ~30 tests in.
+which baton-do
+baton-do --version
+
+# `ginkgo -r --race` mirrors extendo's own `make test` target.
+# -r recursively walks the test suites; --race enables the Go
+# race detector to catch any goroutine-related regressions.
+ginkgo -r --race

--- a/.github/scripts/test-extendo.sh
+++ b/.github/scripts/test-extendo.sh
@@ -120,12 +120,27 @@ go install github.com/onsi/ginkgo/v2/ginkgo
 which baton-do
 baton-do --version
 
-# Mirrors extendo's own `make test` target plus a verbosity bump
-# for CI logs:
-#   -r        recursively walk test suites
-#   --race    enable the Go race detector
-#   -v        print each spec name as it runs (default is a
-#             dot-per-test summary, which makes a hang invisible
-#             — `Random Seed: ... Will run N of N specs` is the
-#             last thing you see before stdout goes quiet)
-ginkgo -r --race -v
+# Mirrors extendo's own `make test` target plus three diagnostics
+# adjustments for CI:
+#   -r                       recursively walk test suites
+#   --race                   enable the Go race detector
+#   -v                       print each spec name as it runs
+#                            (default is a dot-per-test summary
+#                            which makes a hang invisible)
+#   --timeout=10m            bound the whole suite. Without this
+#                            Ginkgo's default is one hour, so a
+#                            hung spec would tie up the runner
+#                            until GitHub Actions' job-level
+#                            timeout fires instead.
+#   --poll-progress-after=30s
+#   --poll-progress-interval=15s
+#                            if a spec sits longer than 30 s, dump
+#                            the goroutine stacks so we can see
+#                            *where* the hang is — repeated every
+#                            15 s after the first dump. The suite
+#                            normally completes in under a minute,
+#                            so 30 s on a single spec is already
+#                            suspicious.
+ginkgo -r --race -v \
+    --timeout=10m \
+    --poll-progress-after=30s --poll-progress-interval=15s

--- a/.github/workflows/extendo-tests.yml
+++ b/.github/workflows/extendo-tests.yml
@@ -1,0 +1,96 @@
+name: "Extendo compatibility tests"
+
+# Trigger budget is deliberately permissive while this workflow
+# is being iterated on: run on every push and every PR so failure
+# modes surface fast. Once the suite is stable across CI runs,
+# tighten to the partisan pattern (`pull_request`, `push` to main,
+# and `push` to branches matching `**compat_extendo**`) to keep
+# the Actions bill sensible. See `partisan-tests.yml` for the
+# target end state.
+on: [push, pull_request]
+
+# End-to-end run of extendo's Ginkgo suite against baton-rs
+# binaries. Extendo is a Go consumer of the baton-do wire envelope;
+# adds a second downstream-consumer compat dimension on top of
+# `partisan-tests.yml`. Tracks #76.
+#
+# Why this workflow doesn't call the `_irods-test.yml` reusable
+# workflow: extendo needs a Go toolchain install cached across
+# runs, which has no business in the unit-tests pipeline. We
+# duplicate the ~15-line iRODS service-container block to keep the
+# reusable workflow uncomplicated.
+#
+# Matrix runs the full 4.2.7 / 4.3.4 / 4.3.5 trio. Unlike the
+# partisan workflow, 4.2.7 (Ubuntu 16.04, OpenSSL 1.0.2) is
+# tractable here because Go's release tarballs are statically
+# linked and don't pull modern OpenSSL the way pyenv's Python
+# build does.
+#
+# Informational long-term (`continue-on-error: true`): extendo
+# is a downstream consumer pinned to a single SHA, so its tests
+# carry information about wire-compat regressions but shouldn't
+# gate merges on the baton-rs side. Same policy as the partisan
+# workflow.
+jobs:
+  test:
+    name: "extendo / iRODS ${{ matrix.irods }}"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - irods: "4.2.7"
+            build_image: "ghcr.io/wtsi-npg/ub-16.04-irods-clients-dev-4.2.7:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-16.04-irods-4.2.7:latest"
+          - irods: "4.3.4"
+            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.4:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.4:latest"
+          - irods: "4.3.5"
+            build_image: "ghcr.io/wtsi-npg/ub-22.04-irods-clients-dev-4.3.5:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-22.04-irods-4.3.5:latest"
+
+    services:
+      irods-server:
+        image: ${{ matrix.server_image }}
+        ports:
+          - "1247:1247"
+          - "20000-20199:20000-20199"
+        volumes:
+          - /dev/shm:/dev/shm
+        options: >-
+          --health-cmd "nc -z -v localhost 1247"
+          --health-start-period 60s
+          --health-interval 10s
+          --health-timeout 20s
+          --health-retries 6
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      # Cache the Go toolchain + GOPATH (downloaded modules,
+      # ginkgo binary) so subsequent runs skip the ~30 s
+      # tarball + go-mod-download work. Key on the script + pin
+      # file so any bump (Go version, extendo pin, install
+      # logic) invalidates the cache automatically. Path is
+      # workspace-relative because that's the directory the
+      # build action mounts into the container.
+      - name: "Cache Go toolchain + GOPATH"
+        uses: actions/cache@v4
+        with:
+          path: .go-cache
+          key: go-${{ matrix.irods }}-${{ hashFiles('.github/scripts/test-extendo.sh', '.github/scripts/extendo-pin') }}
+          restore-keys: |
+            go-${{ matrix.irods }}-
+
+      - name: "Run extendo ginkgo"
+        uses: wtsi-npg/build-irods-client-action@v1.1.1
+        with:
+          build-image: ${{ matrix.build_image }}
+          build-script: .github/scripts/test-extendo.sh
+          docker-network: ${{ job.services.irods-server.network }}
+
+      - name: "Show test log"
+        if: ${{ failure() }}
+        run: find "$GITHUB_WORKSPACE" -name "*.log" -exec cat {} \;


### PR DESCRIPTION
## Summary

Adds the extendo compatibility workflow alongside the partisan one. Extendo is a Go consumer of the \`baton-do\` wire envelope; running its Ginkgo suite against baton-rs binaries catches wire-compat regressions partisan may not exercise. Closes #76.

Informational long-term (\`continue-on-error: true\`), same policy as the partisan workflow.

## How it got to green

The first run on this branch surfaced four extendo failures: a 5-minute hang on every spec (envelope ID lost) plus three error-shape mismatches. Fixed across four merges into \`main\`:

| PR | Fix |
|---|---|
| #80 | Envelope round-trip: \`BatonDoEnvelope.extra\` captures unknown top-level fields (extendo's \`"ID"\` correlation key) and echoes them on \`BatonDoOutput\` |
| #81 | Put honours \`irods_default_resource\` from the env (extendo expects two replicas on \`replResc\`'s children) + CHKSUM_ALL_KW + FORCE on the post-put checksum read |
| #82 | Pin extendo to \`v3.1.0\` (\`b24b63c…\`) — tagged release rather than \`devel\` HEAD |
| #83 | Surface real iRODS codes (-310000, -403000) instead of synthetic \`-1\` on 17 validation paths — closes the last two extendo failures (\`Archive a DataObject when archiving a collection\`, \`Put a directory without recursion\`) |

After all four merged, \`feat/extendo-ci\` rebased green: 97/97 specs passing in ~71 s.

## Files

- **\`.github/scripts/extendo-pin\`** — single-line SHA of the pinned extendo commit (\`b24b63c…\`, extendo v3.1.0).
- **\`.github/workflows/extendo-tests.yml\`** — matrix over 4.2.7 / 4.3.4 / 4.3.5. Unlike the partisan workflow, all three iRODS versions run: Go's static tarballs work on Ubuntu 16.04 (where partisan's Python 3.12 pyenv build doesn't). \`continue-on-error: true\` keeps any per-version failure informational.
- **\`.github/scripts/test-extendo.sh\`** — runs inside the build image. Bootstraps Rust + iRODS client the same way \`docker/build.sh\` does, sets \`STRICT_BATON_COMPAT=1\` for downstream-compat reporting, downloads Go 1.24.1 to a workspace-relative \`.go-cache/\` so \`actions/cache@v4\` can persist it across runs, clones extendo at the pinned commit, runs \`ginkgo -r --race -v\` with \`--timeout=10m --poll-progress-after=30s --poll-progress-interval=15s\`.

## Diagnostic flags on ginkgo

- \`-v\` — print each spec name as it runs (default is a dot-per-test, makes hangs invisible).
- \`--timeout=10m\` — bound the whole suite. Default is 1 h; with a hang that's an entire runner-slot wasted before GH-Actions' job timeout fires.
- \`--poll-progress-after=30s\` + \`--poll-progress-interval=15s\` — if any spec sits longer than 30 s, ginkgo emits a goroutine-stack progress report and repeats every 15 s. Surfaces *where* a hang is happening, not just *that*.

These were load-bearing during the cluster work — without \`--poll-progress-after\`, we wouldn't have seen the \`(*Client).send\` stack pointing at the missing-\`ID\`-correlation hang.

## Test plan

- [x] All three matrix legs green on the rebased branch (97/97 specs passing)
- [x] Warm-cache run reuses the Go toolchain + GOPATH without re-downloading
- [x] No regression on partisan workflow or unit-tests

## Refs

- Closes #76 — extendo compatibility test workflow
- Builds on #80 / #81 / #82 / #83 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)