### PR TITLE
release: 1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Tag format is bare semver (no `v` prefix) — the git tag matches
 `Cargo.toml`'s `version` field byte-for-byte.
 
-## [1.0.0-alpha.0] — 2026-05-13
+## [1.0.0-alpha.1] — 2026-05-13
 
 First public preview. Wire-compatible with upstream
 [baton](https://github.com/wtsi-npg/baton) 6.0.0 for the success path
@@ -51,4 +51,4 @@ README.
   today. Pluggable hash-scheme support is tracked in #31, the matrix
   in #27.
 
-[1.0.0-alpha.0]: https://github.com/jmtcsngr/baton-rs/releases/tag/1.0.0-alpha.0
+[1.0.0-alpha.1]: https://github.com/jmtcsngr/baton-rs/releases/tag/1.0.0-alpha.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "baton-rs"
-version     = "1.0.0-alpha.0"
+version     = "1.0.0-alpha.1"
 edition     = "2021"
 license     = "GPL-2.0"
 description = "Rust reimplementation of baton, the iRODS metadata client. Wire-compatible with upstream baton 6.0.0."

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ when running such consumers against baton-rs.
 
 ```sh
 $ baton-do --version
-1.0.0-alpha.0
+1.0.0-alpha.1
 
 $ STRICT_BATON_COMPAT=1 baton-do --version
 6.0.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,7 +92,19 @@ Open the PR, wait for unit-tests CI green, merge.
 
 ```sh
 git checkout main
+git fetch origin
 git pull --ff-only
+
+# Verify local main matches origin/main. Tagging stale main produces a
+# tag pointing at a commit predating the release-prep PR; the published
+# container then reports the old Cargo.toml version instead of the tag.
+[ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] \
+  || { echo "main is not at origin/main — pull before tagging"; exit 1; }
+
+# HEAD should be the release-prep PR's merge commit.
+git log -1 --oneline
+# Expected: <sha> release: <version> (#NN)
+
 git tag -a <version> -m "<version> release"
 git push origin <version>
 ```
@@ -101,8 +113,17 @@ The tag triggers `.github/workflows/publish.yml`, which builds release
 binaries in the iRODS-clients-dev container, then builds and pushes
 the runtime image to `ghcr.io/jmtcsngr/baton-rs` with these tags:
 
-- Always: `<version>` (e.g. `1.0.0-alpha.0`).
+- Always: `<version>` (e.g. `1.0.0-alpha.1`).
 - Non-prerelease only: `<major>.<minor>` (e.g. `1.0`) and `latest`.
+
+After the workflow finishes, confirm the tag resolves to the merge
+commit you expected:
+
+```sh
+gh api repos/jmtcsngr/baton-rs/git/refs/tags/<version> \
+  --jq '.object.sha'
+# Should match the `git log -1 --oneline` SHA from above.
+```
 
 Watch the run:
 


### PR DESCRIPTION
## Summary

Supersedes #94 (1.0.0-alpha.0), whose tag was pushed against stale
local `main` and so pointed at the commit *before* the release-prep
PR was merged. The container published under that tag therefore
reports the old `Cargo.toml` version (`0.1.0`) instead of the tag
itself. Per `RELEASING.md` the broken tag stays in history; this PR
targets `1.0.0-alpha.1` as the first usable release.

Two commits:

- `chore: bump version to 1.0.0-alpha.1` — `Cargo.toml`, README
  `--version` example, and CHANGELOG heading + footnote link all
  bumped together.
- `docs(release): require local main = origin/main before tagging`
  — `RELEASING.md` step 4 now requires an explicit `git rev-parse`
  equality check before tagging, plus a post-push dereference that
  confirms the annotated tag points at the expected merge commit.
  Closes the failure mode that bit `1.0.0-alpha.0`.

## Follow-ups (not blocking this PR)

- `ghcr.io/jmtcsngr/baton-rs:latest` currently points at the broken
  alpha.0 build. Prerelease tags don't move `:latest` (gated in
  `publish.yml`), so this won't auto-correct until a stable release.
  Recommended action: delete the `:latest` tag in GHCR manually.
- Manifest pre-flight check in `publish.yml` (#93) is still a sensible
  defence-in-depth.

## Test plan

- [ ] Unit-tests green on `release/1.0.0-alpha.1`
- [ ] `cargo audit` clean
- [ ] Cargo.toml manifest validated locally (`cargo verify-project`)
- [ ] After merge, follow updated `RELEASING.md` step 4 — verify
      `git rev-parse main = git rev-parse origin/main` before tagging
- [ ] After tag push, verify tag dereferences to the merge commit
      via `gh api repos/jmtcsngr/baton-rs/git/refs/tags/1.0.0-alpha.1`
- [ ] `docker run --rm ghcr.io/jmtcsngr/baton-rs:1.0.0-alpha.1 --version`
      reports `1.0.0-alpha.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)