### PR TITLE
release: 1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Tag format is bare semver (no `v` prefix) — the git tag matches
 `Cargo.toml`'s `version` field byte-for-byte.
 
-## [1.0.0-alpha.2] — 2026-05-13
+## [1.0.0-alpha.2] — 2026-05-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Tag format is bare semver (no `v` prefix) — the git tag matches
 `Cargo.toml`'s `version` field byte-for-byte.
 
+## [1.0.0-alpha.2] — 2026-05-13
+
+### Changed
+
+- **Container entrypoint pattern aligned with upstream baton.**
+  Dropped `ENTRYPOINT ["/usr/local/bin/baton-do"]` in favour of
+  `CMD ["/bin/bash"]` and no entrypoint, matching upstream's dev image
+  convention. Callers that relied on `docker run image --version` or
+  `singularity run docker://image --version` need to switch to an
+  explicit invocation — e.g. `docker run image baton-do --version` or
+  `singularity exec docker://image baton-do --version`.
+- Container runs as non-root `appuser` (UID/GID 1000). Under
+  singularity the host user takes over; under plain `docker run` the
+  container runs unprivileged.
+- Container default locale set to `en_GB.UTF-8`; `TZ` set to
+  `Etc/UTC`.
+- iRODS runtime version parameterised via `ARG IRODS_VERSION` (default
+  `4.3.5`). Override at build time only if rebuilding against a
+  matched custom binary set.
+- APT repo signing key migrated from the deprecated `apt-key add`
+  pattern to `gpg --dearmor` + `signed-by=` keyring under
+  `/etc/apt/keyrings/`. No user-visible change.
+
+[1.0.0-alpha.2]: https://github.com/jmtcsngr/baton-rs/releases/tag/1.0.0-alpha.2
+
 ## [1.0.0-alpha.1] — 2026-05-13
 
 First public preview. Wire-compatible with upstream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "baton-rs"
-version     = "1.0.0-alpha.1"
+version     = "1.0.0-alpha.2"
 edition     = "2021"
 license     = "GPL-2.0"
 description = "Rust reimplementation of baton, the iRODS metadata client. Wire-compatible with upstream baton 6.0.0."

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ when running such consumers against baton-rs.
 
 ```sh
 $ baton-do --version
-1.0.0-alpha.1
+1.0.0-alpha.2
 
 $ STRICT_BATON_COMPAT=1 baton-do --version
 6.0.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,24 +1,53 @@
 FROM ubuntu:22.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Bootstrap: tools needed to fetch the iRODS APT repo signing key, plus
+# the `locales` package so the container speaks UTF-8 by default.
+# Mirrors upstream baton's dev image conventions
+# (wtsi-npg/baton:Dockerfile.ubuntu-*-dev).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    wget \
-    gnupg \
-    lsb-release \
+        ca-certificates \
+        gnupg \
+        locales \
+        lsb-release \
+        wget \
+    && locale-gen en_GB en_GB.UTF-8 \
+    && localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install iRODS client runtime packages from the official iRODS APT repository.
-# The exact version must match the iRODS version the build image compiled against
-# (currently 4.3.5 — see the build image referenced in publish.yml).
-RUN wget -qO - https://packages.irods.org/irods-signing-key.asc \
-      | apt-key add - \
-  && echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" \
+ENV LANG=en_GB.UTF-8 \
+    LANGUAGE=en_GB \
+    LC_ALL=en_GB.UTF-8 \
+    TZ=Etc/UTC
+
+# iRODS client runtime packages from the official iRODS APT repository.
+# `IRODS_VERSION` defaults to the version baton-rs binaries were compiled
+# against in `publish.yml`'s build image. Override at build time
+# (`--build-arg IRODS_VERSION=4.3.4`) only if rebuilding the image
+# against a matching custom binary set.
+ARG IRODS_VERSION="4.3.5"
+
+RUN install -d -m 0755 /etc/apt/keyrings \
+  && wget -qO- https://packages.irods.org/irods-signing-key.asc \
+       | gpg --dearmor -o /etc/apt/keyrings/irods-archive-keyring.gpg \
+  && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/irods-archive-keyring.gpg] https://packages.irods.org/apt/ $(lsb_release -sc) main" \
       > /etc/apt/sources.list.d/renci-irods.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-       irods-runtime=4.3.5-0~jammy \
-       irods-icommands=4.3.5-0~jammy \
+       "irods-runtime=${IRODS_VERSION}-0~$(lsb_release -sc)" \
+       "irods-icommands=${IRODS_VERSION}-0~$(lsb_release -sc)" \
   && rm -rf /var/lib/apt/lists/*
+
+# Non-root user mirroring upstream baton's `appuser` (UID/GID 1000).
+# Under singularity the host user takes over; under plain `docker run`
+# the container runs unprivileged by default.
+ARG APP_USER=appuser
+ARG APP_UID=1000
+ARG APP_GID=$APP_UID
+
+RUN groupadd --gid $APP_GID $APP_USER \
+ && useradd --uid $APP_UID --gid $APP_GID --shell /bin/bash --create-home $APP_USER
 
 COPY target/release/baton-list       /usr/local/bin/
 COPY target/release/baton-get        /usr/local/bin/
@@ -28,4 +57,11 @@ COPY target/release/baton-metamod    /usr/local/bin/
 COPY target/release/baton-metaquery  /usr/local/bin/
 COPY target/release/baton-do         /usr/local/bin/
 
-ENTRYPOINT ["/usr/local/bin/baton-do"]
+USER $APP_USER
+WORKDIR /app
+
+# Container as a working environment, no implicit entrypoint binary.
+# Mirrors upstream baton's `CMD ["/bin/bash"]`. Invoke any binary
+# explicitly, e.g. `docker run image baton-do --version` or
+# `singularity exec docker://image baton-list /path`.
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

Second alpha release. Per RELEASING.md's process: version bump + changelog entry, plus the Docker image alignment work that motivated it.

- **Docker image alignment with upstream baton conventions**:
  - Drops `ENTRYPOINT ["/usr/local/bin/baton-do"]` in favor of `CMD ["/bin/bash"]` -- matches upstream's dev-image convention, no implicit entrypoint. Callers relying on `docker run image --version` need to switch to an explicit invocation (`docker run image baton-do --version`).
  - Runs as non-root `appuser` (UID/GID 1000).
  - Container locale set to `en_GB.UTF-8`; `TZ=Etc/UTC`.
  - iRODS runtime version parameterised via `ARG IRODS_VERSION` (default `4.3.5`).
  - APT signing-key pattern migrated from deprecated `apt-key add` to `gpg --dearmor` + `signed-by=` keyring.
- **Version bump**: `Cargo.toml` and README's example `--version` output, `1.0.0-alpha.1` -> `1.0.0-alpha.2`.
- **Changelog**: `1.0.0-alpha.2` entry added, dated 2026-05-14.

This branch was cut before the 6.1.0 compat work (PR #102) and PLAN.md fix (PR #103) landed on `main`. `main` is otherwise a superset of this branch's diff -- confirmed no conflicts via `git merge-tree` before opening this PR, so merging `main` should bring both sets of changes together cleanly.

## Test plan

- [x] Unit-tests CI green on the 4.2.7 / 4.3.4 / 4.3.5 matrix
- [x] `cargo audit` clean
- [x] Docker image builds and the new entrypoint behavior (`docker run image baton-do --version`) works as documented