### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Tag format is bare semver (no `v` prefix) — the git tag matches
 `Cargo.toml`'s `version` field byte-for-byte.
 
+## [1.0.0] — 2026-07-23
+
+First stable release. Full wire-compat with upstream baton 6.1.0
+across all seven binaries, continuously validated against partisan
+and extendo.
+
+### Notes
+
+- Known limitations, documented rather than fixed: cross-zone
+  metaquery scoping ([#77]) and hash schemes beyond MD5 ([#31],
+  matrix in [#27]).
+
+[1.0.0]: https://github.com/jmtcsngr/baton-rs/releases/tag/1.0.0
+[#77]: https://github.com/jmtcsngr/baton-rs/issues/77
+[#31]: https://github.com/jmtcsngr/baton-rs/issues/31
+[#27]: https://github.com/jmtcsngr/baton-rs/issues/27
+
 ## [1.0.0-alpha.2] — 2026-05-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "baton-rs"
-version     = "1.0.0-alpha.2"
+version     = "1.0.0"
 edition     = "2021"
 license     = "GPL-2.0"
 description = "Rust reimplementation of baton, the iRODS metadata client. Wire-compatible with upstream baton 6.1.0."

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A Rust reimplementation of [baton](https://github.com/wtsi-npg/baton), the iRODS
 client focused on metadata operations via a single JSON interface. Targets
 wire-compat with upstream baton **6.1.0**.
 
-**Status:** Under active development. The seven binaries are implemented and
-exercised against iRODS 4.2.7 / 4.3.4 / 4.3.5 in CI, plus integration runs
-against the downstream Python ([partisan](https://github.com/wtsi-npg/partisan))
-and Go ([extendo](https://github.com/wtsi-npg/extendo)) consumers. See
+**Status:** Stable (1.0.0). All seven binaries are implemented and exercised
+against iRODS 4.2.7 / 4.3.4 / 4.3.5 in CI, plus integration runs against the
+downstream Python ([partisan](https://github.com/wtsi-npg/partisan)) and Go
+([extendo](https://github.com/wtsi-npg/extendo)) consumers. See
 [`PLAN.md`](PLAN.md) for the multi-session implementation plan and
 [`SESSIONS.md`](SESSIONS.md) for session progress and cross-cutting
 conventions.
@@ -122,7 +122,7 @@ when running such consumers against baton-rs.
 
 ```sh
 $ baton-do --version
-1.0.0-alpha.2
+1.0.0
 
 $ STRICT_BATON_COMPAT=1 baton-do --version
 6.1.0


### PR DESCRIPTION
## Summary

First stable release. baton-rs graduates from the alpha program (`1.0.0-alpha.0`-`.2`) -- no source-code behavior changes, just declaring stability.

- `Cargo.toml` version bump: `1.0.0-alpha.2` -> `1.0.0`.
- `README.md`: "Status" line updated from "Under active development" to "Stable (1.0.0)"; the `STRICT_BATON_COMPAT` example's version output updated.
- `CHANGELOG.md`: new `## [1.0.0]` entry -- full wire-compat with upstream baton 6.1.0 across all seven binaries, continuously validated against partisan and extendo. Notes the two known, documented limitations (cross-zone metaquery scoping #77, hash schemes beyond MD5 #31/#27) that are shipping as-is rather than being fixed for this release -- a deliberate scope decision.

Per `RELEASING.md`'s pre-release checklist, already verified (read-only, before opening this PR):
- `unit-tests.yml`, `cargo-audit.yml`, `partisan-tests.yml`, `extendo-tests.yml` all green on `main`.
- Docker/build-image iRODS pin agreement (`4.3.5` both sides).
- Downstream pins (`partisan-pin`, `extendo-pin`) reviewed this session, no further bump needed.
- Sanity grep for stale `1.0.0-alpha.2` references: clean (only expected historical hits in CHANGELOG.md and SESSIONS.md's session log).

## Test plan

- [ ] CI green on this PR (unit-tests matrix, cargo-audit, partisan, extendo)
- [ ] After merge: tag `1.0.0`, verify publish, verify `:1.0`/`:latest` now populate (first non-prerelease tag)