### PR TITLE
release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Tag format is bare semver (no `v` prefix) — the git tag matches
 `Cargo.toml`'s `version` field byte-for-byte.
 
+## [1.0.1] — 2026-07-24
+
+### Fixed
+
+- `extendo-tests.yml` no longer runs on tag pushes ([#110]).
+
+[1.0.1]: https://github.com/jmtcsngr/baton-rs/releases/tag/1.0.1
+[#110]: https://github.com/jmtcsngr/baton-rs/issues/110
+
 ## [1.0.0] — 2026-07-23
 
 First stable release. Full wire-compat with upstream baton 6.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "baton-rs"
-version     = "1.0.0"
+version     = "1.0.1"
 edition     = "2021"
 license     = "GPL-2.0"
 description = "Rust reimplementation of baton, the iRODS metadata client. Wire-compatible with upstream baton 6.1.0."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust reimplementation of [baton](https://github.com/wtsi-npg/baton), the iRODS
 client focused on metadata operations via a single JSON interface. Targets
 wire-compat with upstream baton **6.1.0**.
 
-**Status:** Stable (1.0.0). All seven binaries are implemented and exercised
+**Status:** Stable (1.0.1). All seven binaries are implemented and exercised
 against iRODS 4.2.7 / 4.3.4 / 4.3.5 in CI, plus integration runs against the
 downstream Python ([partisan](https://github.com/wtsi-npg/partisan)) and Go
 ([extendo](https://github.com/wtsi-npg/extendo)) consumers. See
@@ -122,7 +122,7 @@ when running such consumers against baton-rs.
 
 ```sh
 $ baton-do --version
-1.0.0
+1.0.1
 
 $ STRICT_BATON_COMPAT=1 baton-do --version
 6.1.0


### PR DESCRIPTION
## Summary

Patch release. CI-only fix, no source-code behavior change.

- `Cargo.toml` version bump: `1.0.0` -> `1.0.1`.
- `README.md`: status line and version example updated.
- `CHANGELOG.md`: new `## [1.0.1]` entry -- extendo-tests.yml no longer runs on tag pushes (#110, fixed in #111).

Sanity grep for stale `1.0.0` references: clean (only expected historical/generic hits in CHANGELOG.md, SESSIONS.md, RELEASING.md, publish.yml).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: tag `1.0.1`, verify publish, confirm extendo-tests.yml does NOT fire on the tag push (the actual fix under test)